### PR TITLE
(maint) fix css snippet links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To run commands listed below, either:
 - **[Admonitions](obsidian://show-plugin?id=obsidian-admonition)**: One of the templates for rendering monsters uses the code-style format supported by the admonitions plugin to render human-readable text (and avoid blockquote line wrapping).
   - Create a custom admonition called `statblock` (I recommend a dragon icon)
   - Create a custom admonition called `flowchart` (I recommend a map icon)
-  - Either set the appearance/icon for the style in the plugin, or use/modify [this snippet](css-snippets/admonition_callout.css) to style the admonition.
-  - The [compendium snippet](css-snippets/compendium.css) defines styles for the contents of the statblock, including setting the size of the token image based on the #token anchor in the link.
+  - Either set the appearance/icon for the style in the plugin, or use/modify [this snippet](examples/css-snippets/admonition_callout.css) to style the admonition.
+  - The [compendium snippet](examples/css-snippets/compendium.css) defines styles for the contents of the statblock, including setting the size of the token image based on the #token anchor in the link.
 
 - **[Force note view mode by front matter](obsidian://show-plugin?id=obsidian-view-mode-by-frontmatter)**: I use this plugin to treat these generated notes as essentially read only. Specifically, I ensure the plugin has the following options enabled: "Ignore open files" (so that if I have toggled to edit mode, it doesn't fight with me over it), and "Ignore force view when not in front matter" (so that the setting isn't applied to documents that don't have the front matter tag).
 


### PR DESCRIPTION
A couple of the css-snippet links in the README were pointing at `/css-snippets` rather than `/examples/css-snippets`. This commit fixes those links.