### PR TITLE
🐛 RegisterForReflection needed for YAML type

### DIFF
--- a/src/main/java/dev/ebullient/convert/qute/NamedText.java
+++ b/src/main/java/dev/ebullient/convert/qute/NamedText.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import io.quarkus.qute.TemplateData;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * Holder of a name or category and associated descriptive text.
@@ -16,6 +17,7 @@ import io.quarkus.qute.TemplateData;
  * </p>
  */
 @TemplateData
+@RegisterForReflection
 public class NamedText {
     public final static Comparator<NamedText> comparator = Comparator.comparing(NamedText::getKey);
 


### PR DESCRIPTION
NamedText is passed to Jackson to render as YAML using reflection. This is different than / beyond what Quarkus sees for Qute.