### PR TITLE
Migrate to 5etools mirror2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ Using the GitHub CLI:
 ```shell
 mkdir -p sources
 # 5eTools
-gh repo clone 5etools-mirror-1/5etools-mirror-1.github.io sources/5etools-mirror-1.github.io -- --depth=1
+gh repo clone 5etools-mirror-2/5etools-mirror-2.github.io sources/5etools-mirror-2.github.io -- --depth=1
+gh repo clone 5etools-mirror-2/5etools-img 5etools-mirror-2.github.io/img -- --depth=1
 gh repo clone TheGiddyLimit/homebrew sources/5e-homebrew -- --depth=1
 gh repo clone TheGiddyLimit/unearthed-arcana sources/5e-unearthed-arcana -- --depth=1
 # PF2eTools

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -78,9 +78,9 @@ public class Json2QuteCommon implements JsonSource {
     }
 
     Path getTokenSourcePath(String filename) {
-        return Path.of("img",
+        return Path.of("img", "bestiary", "tokens",
                 getSources().mapPrimarySource(),
-                filename + ".png");
+                filename + ".webp");
     }
 
     public String getText(String heading) {
@@ -710,7 +710,7 @@ public class Json2QuteCommon implements JsonSource {
 
             Path target = Path.of(getImagePath(),
                     "token",
-                    slugify(filename) + ".png");
+                    slugify(filename) + ".webp");
 
             return buildImageRef(sourcePath, target);
         } else if (tokenString != null) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteObject.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteObject.java
@@ -64,7 +64,7 @@ public class Json2QuteObject extends Json2QuteMonster {
     Path getTokenSourcePath(String filename) {
         return Path.of("img", "objects", "tokens",
                 getSources().mapPrimarySource(),
-                filename + ".png");
+                filename + ".webp");
     }
 
     enum ObjectFields implements JsonNodeReader {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
@@ -60,7 +60,7 @@ public class Json2QuteVehicle extends Json2QuteCommon {
     Path getTokenSourcePath(String filename) {
         return Path.of("img", "vehicles", "tokens",
                 getSources().mapPrimarySource(),
-                filename + ".png");
+                filename + ".webp");
     }
 
     String vehicleSize(Tags tags) {

--- a/src/test/java/dev/ebullient/convert/TestUtils.java
+++ b/src/test/java/dev/ebullient/convert/TestUtils.java
@@ -35,7 +35,7 @@ public class TestUtils {
     public final static Path TEST_RESOURCES = PROJECT_PATH.resolve("src/test/resources/");
 
     // for compile/test purposes. Must clone/sync separately.
-    public final static Path PATH_5E_TOOLS_DATA = PROJECT_PATH.resolve("sources/5etools-mirror-1.github.io/data");
+    public final static Path PATH_5E_TOOLS_DATA = PROJECT_PATH.resolve("sources/5etools-mirror-2.github.io/data");
     public final static Path PATH_5E_HOMEBREW = PROJECT_PATH.resolve("sources/5e-homebrew");
     public final static Path PATH_5E_UA = PROJECT_PATH.resolve("sources/5e-unearthed-arcana");
     public final static Path TOOLS_PATH_PF2E = PROJECT_PATH.resolve("sources/Pf2eTools/data");


### PR DESCRIPTION
**Note:** Changes will likely break CI build: _.github/workflows/tools-data.yml_

I see that the build is pulling the released gz file then doing some magic to use file links instead of the actual images. With the transition to a separate repo for the images, there will need to be some massaging to this.

- updated references from  5etools-mirror-1 to 5etools-mirror-2
- updated get token functions to use .webp instead of .png
- added additional directory paths for monster token

