### PR TITLE
Get some more debug output [DO NOT MERGE]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- Quarkus -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.8.2</quarkus.platform.version>
+        <quarkus.platform.version>3.8.3</quarkus.platform.version>
         <!-- Libraries -->
         <assertj.version>3.25.3</assertj.version>
         <evalex.version>3.1.2</evalex.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ quarkus.test.continuous-testing=enabled
 quarkus.arc.detect-unused-false-positives=false
 
 quarkus.native.resources.includes=*.json,*.svg,*.properties,*.txt
-quarkus.native.additional-build-args=--enable-url-protocols=https
+quarkus.native.additional-build-args=--enable-url-protocols=https,-H:Log=registerResource:3
 


### PR DESCRIPTION
See https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Flummoxed.2E.20Qute.20not.20finding.20templates.20on.20Windows.2010

This should output which resources are included in the native executable.

It would be great if you could add `-Dorg.slf4j.simpleLogger.log.io.quarkus=debug` to the maven command -> we should see the DEBUG messages logged by quarkus extensions during build, i.e. something like `mvn clean package -DskipTests -Dorg.slf4j.simpleLogger.log.io.quarkus=debug`.