### PR TITLE
Add a stringutil helper and incidentally fix some string-related bugs

### DIFF
--- a/src/main/java/dev/ebullient/convert/StringUtil.java
+++ b/src/main/java/dev/ebullient/convert/StringUtil.java
@@ -213,11 +213,6 @@ public class StringUtil {
         return pluralize(s, howMany, false);
     }
 
-    /** @see #pluralize(String, int) */
-    public static String pluralize(String s, String howMany) {
-        return pluralize(s, Integer.parseInt(howMany));
-    }
-
     /**
      * Return the given string surrounded in parentheses. Return null if the input is null, or an empty string if
      * the input is empty.

--- a/src/main/java/dev/ebullient/convert/StringUtil.java
+++ b/src/main/java/dev/ebullient/convert/StringUtil.java
@@ -1,56 +1,103 @@
 package dev.ebullient.convert;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 /**
  * Holds common, generic string utiltity methods.
  *
- * <p>This should only contain string utility methods which don't involve any domain-specific manipulation or knowledge.
+ * <p>
+ * This should only contain string utility methods which don't involve any domain-specific manipulation or knowledge.
  * Those should instead go in a {@link dev.ebullient.convert.tools.JsonTextConverter} or a
- * {@link dev.ebullient.convert.tools.JsonNodeReader}.</p>
+ * {@link dev.ebullient.convert.tools.JsonNodeReader}.
+ * </p>
  */
 public class StringUtil {
+
     /**
-     * Returns the given strings joined into a single trimmed string using the given delimiter, or an empty string if
-     * the input list is null or empty.
+     * {@link #join(String, Collection)} but with the ability to accept varargs.
+     *
+     * @see #join(String, Collection)
+     */
+    public static String join(String joiner, Object o1, Object... rest) {
+        List<Object> args = new ArrayList<>();
+        args.add(o1);
+        args.addAll(Arrays.asList(rest));
+        return join(joiner, args);
+    }
+
+    /**
+     * Join the list into a single trimmed string, delimited using the given delimiter. Returns an empty string if the
+     * input list is null or empty, and ignores empty and null input elements.
      *
      * @param joiner The delimiter to use to join the strings
      * @param list The input strings to join together
      */
-    public static String join(String joiner, Collection<String> list) {
-        if (list == null || list.isEmpty()) {
+    public static String join(String joiner, Collection<?> list) {
+        return list == null ? "" : list.stream().collect(joiningNonEmpty(joiner)).trim();
+    }
+
+    /**
+     * Like {@link #join(String, Collection)} but acts on a number of collections by first flattening them into a single
+     * collection.
+     */
+    public static String flatJoin(String joiner, Collection<?>... lists) {
+        return join(joiner, Arrays.stream(lists).flatMap(Collection::stream).toList());
+    }
+
+    /**
+     * {@link #joinWithPrefix(String, Collection, String, String)} with an empty suffix.
+     *
+     * @see #joinWithPrefix(String, Collection, String)
+     */
+    public static String joinWithPrefix(String joiner, Collection<?> list, String prefix) {
+        return joinWithPrefix(joiner, list, prefix, null);
+    }
+
+    /**
+     * Like {@link #join(String, Collection)} but add a prefix (and optionally a suffix) to the resulting string if
+     * it's non-empty.
+     */
+    public static String joinWithPrefix(String joiner, Collection<?> list, String prefix, String suffix) {
+        String s = join(joiner, list);
+        if (s.isEmpty()) {
             return "";
         }
-        return String.join(joiner, list).trim();
+        if (isPresent(prefix)) {
+            s = prefix + s;
+        }
+        if (isPresent(suffix)) {
+            s += suffix;
+        }
+        return s;
     }
 
     /**
-     * Return the given list joined into a comma-delimited string, with an additional delimiter for the last element.
+     * {@link #joinConjunct(String, String, List)} with a {@code ", "} joiner.
      *
-     * <pre>
-     *     joinConjunct(" and ", List.of("one", "two", "three"))  // -> "one, two, and three"
-     * </pre>
-     *
-     * @param list The list of strings to join
-     * @param lastJoiner The delimiter to use for the last element
+     * @see #joinConjunct(List, String, String, boolean)
+     * @see #joinConjunct(String, String, List)
      */
     public static String joinConjunct(String lastJoiner, List<String> list) {
-        return joinConjunct(list, ", ", lastJoiner, false);
+        return joinConjunct(", ", lastJoiner, list);
     }
 
     /**
-     * Return the given list joined into a single string, with an additional delimiter for the last element.
+     * {@link #joinConjunct(List, String, String, boolean)} with a false {@code nonOxford}.
      *
-     * <pre>
-     *     joinConjunct(", ", " and ", List.of("one", "two", "three"))  // -> "one, two, and three"
-     * </pre>
-     *
-     * @param joiner The delimiter to use for all elements
-     * @param list The list of strings to join
-     * @param lastJoiner The additional delimiter to add before the last element
+     * @see #joinConjunct(List, String, String, boolean)
+     * @see #joinConjunct(String, List)
      */
     public static String joinConjunct(String joiner, String lastJoiner, List<String> list) {
         return joinConjunct(list, joiner, lastJoiner, false);
@@ -66,7 +113,8 @@ public class StringUtil {
      *
      * @param list The list of strings to join
      * @param joiner The delimiter to use for all elements except the last
-     * @param lastJoiner The delimiter to add before the last element (or instead of the last delimiter, if {@code nonOxford} is true).
+     * @param lastJoiner The delimiter to add before the last element (or instead of the last delimiter, if {@code nonOxford} is
+     *        true).
      * @param nonOxford If this is true, then don't add a normal delimiter before the final delimiter.
      */
     public static String joinConjunct(List<String> list, String joiner, String lastJoiner, boolean nonOxford) {
@@ -103,10 +151,10 @@ public class StringUtil {
             return text;
         }
         return Arrays.stream(text.split(" "))
-            .map(word -> word.isEmpty()
-                ? word
-                : Character.toTitleCase(word.charAt(0)) + word.substring(1).toLowerCase())
-            .collect(Collectors.joining(" "));
+                .map(word -> word.isEmpty()
+                        ? word
+                        : Character.toTitleCase(word.charAt(0)) + word.substring(1).toLowerCase())
+                .collect(Collectors.joining(" "));
     }
 
     /** Returns true if the given string is non-null and non-blank. */
@@ -114,13 +162,154 @@ public class StringUtil {
         return s != null && !s.isBlank();
     }
 
-    /** Return the given string, possibly pluralized based on the number given. */
-    public static String pluralize(String s, int howMany) {
-        return s + (howMany == 1 ? "" : "s");
+    /**
+     * Return the given string pluralized or singularized based on the input number. Use {@code assumeSingular} to
+     * correctly format non-plural inputs which end in 's' (e.g. "walrus").
+     *
+     * <p>
+     * <b>Known Limitations: </b>This does not handle possessives because English is difficult.
+     * </p>
+     *
+     * <p>
+     * Examples:
+     * </p>
+     *
+     * <pre>
+     *     pluralize("foot", 2)    // -> "feet"
+     *     pluralize("feet", 1)    // -> "foot"
+     *     pluralize("mile", 2)    // -> "miles"
+     *     pluralize("miles", 1)   // -> "mile"
+     *     // -> "walrus" (INCORRECT)
+     *     pluralize("walrus", 2, false)
+     *     // -> "walruses" (CORRECT)
+     *     pluralize("walrus", 2, true)
+     * </pre>
+     */
+    public static String pluralize(String s, int howMany, boolean assumeSingular) {
+        if (s == null) {
+            return null;
+        }
+        if (s.isEmpty()) {
+            return "";
+        }
+        if (s.endsWith("s")) {
+            if (assumeSingular) {
+                return s + "es";
+            }
+            s = s.substring(0, s.length() - 2);
+        }
+        return switch (s) {
+            case "foot", "feet" -> howMany == 1 ? "foot" : "feet";
+            default -> howMany == 1 ? s : s + "s";
+        };
     }
 
-    /** Return the given string, possibly pluralized based on the number given. */
+    /**
+     * {@link #pluralize(String, int, boolean)} with {@code assumeSingular} set to {@code false}
+     *
+     * @see #pluralize(String, int, boolean)
+     */
+    public static String pluralize(String s, int howMany) {
+        return pluralize(s, howMany, false);
+    }
+
+    /** @see #pluralize(String, int) */
     public static String pluralize(String s, String howMany) {
-        return s + (howMany.equals("1") ? "" : "s");
+        return pluralize(s, Integer.parseInt(howMany));
+    }
+
+    /**
+     * Return the given string surrounded in parentheses. Return null if the input is null, or an empty string if
+     * the input is empty.
+     */
+    public static String parenthesize(String s) {
+        if (s == null) {
+            return null;
+        }
+        if (s.isBlank()) {
+            return "";
+        }
+        return "(%s)".formatted(s);
+    }
+
+    /** Return the given map as a formatted list of strings, formatted by the given formatter function. */
+    public static <T, U> List<String> formatMap(Map<T, U> map, BiFunction<T, U, String> formatter) {
+        return map.entrySet().stream().map(e -> formatter.apply(e.getKey(), e.getValue())).toList();
+    }
+
+    /**
+     * Returns a collector which performs like {@link #join(String, Collection)}, but usable as a collector for a
+     * stream.
+     */
+    public static <T> JoiningNonEmptyCollector<T> joiningNonEmpty(String delimiter) {
+        return new JoiningNonEmptyCollector<>(delimiter, null, true);
+    }
+
+    /**
+     * {@link #joiningConjunct(String, String)} with a {@code ", "} delimiter.
+     *
+     * @see #joiningConjunct(String, String)
+     */
+    public static <T> JoiningNonEmptyCollector<T> joiningConjunct(String finalDelimiter) {
+        return joiningConjunct(finalDelimiter, ", ");
+    }
+
+    /**
+     * Returns a collector which performs like {@link #joinConjunct(String, String, List)}, but usable as a collector
+     * for a stream.
+     */
+    public static <T> JoiningNonEmptyCollector<T> joiningConjunct(String finalDelimiter, String delimiter) {
+        return new JoiningNonEmptyCollector<>(delimiter, finalDelimiter, true);
+    }
+
+    /**
+     * A {@link java.util.stream.Collector} which converts the elements to strings, and joins the non-empty, non-null
+     * strings into a single string. Allows providing an optional final delimiter that will be inserted before the
+     * last element.
+     *
+     * @param delimiter The delimiter used to join the strings.
+     * @param finalDelimiter The delimiter to use before the last element. Helpful for building strings like e.g.
+     *        "one, two, and three".
+     * @param oxford If false, then don't add a delimiter for the 'oxford comma' - e.g. replace the final delimiter
+     *        with {@code finalDelimiter} rather than adding it.
+     */
+    public record JoiningNonEmptyCollector<T>(
+            String delimiter, String finalDelimiter, Boolean oxford) implements Collector<T, List<String>, String> {
+        @Override
+        public Supplier<List<String>> supplier() {
+            return ArrayList::new;
+        }
+
+        @Override
+        public BiConsumer<List<String>, T> accumulator() {
+            return (acc, cur) -> {
+                if (cur != null && !cur.toString().isBlank()) {
+                    acc.add(cur.toString());
+                }
+            };
+        }
+
+        @Override
+        public BinaryOperator<List<String>> combiner() {
+            return (left, right) -> {
+                left.addAll(right);
+                return left;
+            };
+        }
+
+        @Override
+        public Function<List<String>, String> finisher() {
+            return acc -> {
+                if (isPresent(finalDelimiter)) {
+                    return joinConjunct(acc, delimiter, finalDelimiter, !oxford);
+                }
+                return String.join(delimiter, acc);
+            };
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() {
+            return Set.of();
+        }
     }
 }

--- a/src/main/java/dev/ebullient/convert/StringUtil.java
+++ b/src/main/java/dev/ebullient/convert/StringUtil.java
@@ -1,0 +1,126 @@
+package dev.ebullient.convert;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Holds common, generic string utiltity methods.
+ *
+ * <p>This should only contain string utility methods which don't involve any domain-specific manipulation or knowledge.
+ * Those should instead go in a {@link dev.ebullient.convert.tools.JsonTextConverter} or a
+ * {@link dev.ebullient.convert.tools.JsonNodeReader}.</p>
+ */
+public class StringUtil {
+    /**
+     * Returns the given strings joined into a single trimmed string using the given delimiter, or an empty string if
+     * the input list is null or empty.
+     *
+     * @param joiner The delimiter to use to join the strings
+     * @param list The input strings to join together
+     */
+    public static String join(String joiner, Collection<String> list) {
+        if (list == null || list.isEmpty()) {
+            return "";
+        }
+        return String.join(joiner, list).trim();
+    }
+
+    /**
+     * Return the given list joined into a comma-delimited string, with an additional delimiter for the last element.
+     *
+     * <pre>
+     *     joinConjunct(" and ", List.of("one", "two", "three"))  // -> "one, two, and three"
+     * </pre>
+     *
+     * @param list The list of strings to join
+     * @param lastJoiner The delimiter to use for the last element
+     */
+    public static String joinConjunct(String lastJoiner, List<String> list) {
+        return joinConjunct(list, ", ", lastJoiner, false);
+    }
+
+    /**
+     * Return the given list joined into a single string, with an additional delimiter for the last element.
+     *
+     * <pre>
+     *     joinConjunct(", ", " and ", List.of("one", "two", "three"))  // -> "one, two, and three"
+     * </pre>
+     *
+     * @param joiner The delimiter to use for all elements
+     * @param list The list of strings to join
+     * @param lastJoiner The additional delimiter to add before the last element
+     */
+    public static String joinConjunct(String joiner, String lastJoiner, List<String> list) {
+        return joinConjunct(list, joiner, lastJoiner, false);
+    }
+
+    /**
+     * Return the given list joined into a single string, using a different delimiter for the last element.
+     *
+     * <pre>
+     *     joinConjunct(List.of("one", "two", "three"), ", ", " and ", false)  // "one, two, and three"
+     *     joinConjunct(List.of("one", "two", "three"), ", ", " and ", true)   // "one, two and three"
+     * </pre>
+     *
+     * @param list The list of strings to join
+     * @param joiner The delimiter to use for all elements except the last
+     * @param lastJoiner The delimiter to add before the last element (or instead of the last delimiter, if {@code nonOxford} is true).
+     * @param nonOxford If this is true, then don't add a normal delimiter before the final delimiter.
+     */
+    public static String joinConjunct(List<String> list, String joiner, String lastJoiner, boolean nonOxford) {
+        if (list == null || list.isEmpty()) {
+            return "";
+        }
+        if (list.size() == 1) {
+            return list.get(0);
+        }
+        if (list.size() == 2) {
+            return String.join(lastJoiner, list);
+        }
+
+        int pause = list.size() - 2;
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < list.size(); ++i) {
+            out.append(list.get(i));
+
+            if (i < pause) {
+                out.append(joiner);
+            } else if (i == pause) {
+                if (!nonOxford) {
+                    out.append(joiner.trim());
+                }
+                out.append(lastJoiner);
+            }
+        }
+        return out.toString();
+    }
+
+    /** Return the given text converted to title case, with the first letter of each word capitalized. */
+    public static String toTitleCase(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        return Arrays.stream(text.split(" "))
+            .map(word -> word.isEmpty()
+                ? word
+                : Character.toTitleCase(word.charAt(0)) + word.substring(1).toLowerCase())
+            .collect(Collectors.joining(" "));
+    }
+
+    /** Returns true if the given string is non-null and non-blank. */
+    public static boolean isPresent(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    /** Return the given string, possibly pluralized based on the number given. */
+    public static String pluralize(String s, int howMany) {
+        return s + (howMany == 1 ? "" : "s");
+    }
+
+    /** Return the given string, possibly pluralized based on the number given. */
+    public static String pluralize(String s, String howMany) {
+        return s + (howMany.equals("1") ? "" : "s");
+    }
+}

--- a/src/main/java/dev/ebullient/convert/qute/QuteUtil.java
+++ b/src/main/java/dev/ebullient/convert/qute/QuteUtil.java
@@ -61,12 +61,4 @@ public interface QuteUtil {
             map.put(key, value);
         }
     }
-
-    default String makePlural(String s, int howMany) {
-        return s + (howMany == 1 ? "" : "s");
-    }
-
-    default String makePlural(String s, String howMany) {
-        return s + (howMany.equals("1") ? "" : "s");
-    }
 }

--- a/src/main/java/dev/ebullient/convert/tools/JsonNodeReader.java
+++ b/src/main/java/dev/ebullient/convert/tools/JsonNodeReader.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools;
 
+import static dev.ebullient.convert.StringUtil.join;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,8 +18,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import dev.ebullient.convert.io.Tui;
-
-import static dev.ebullient.convert.StringUtil.join;
 
 public interface JsonNodeReader {
 

--- a/src/main/java/dev/ebullient/convert/tools/JsonNodeReader.java
+++ b/src/main/java/dev/ebullient/convert/tools/JsonNodeReader.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import dev.ebullient.convert.io.Tui;
 
+import static dev.ebullient.convert.StringUtil.join;
+
 public interface JsonNodeReader {
 
     interface FieldValue {
@@ -288,7 +290,7 @@ public interface JsonNodeReader {
         }
         List<String> inner = new ArrayList<>();
         replacer.appendToText(inner, target, null);
-        return replacer.join(join, inner.stream().filter(x -> !x.isBlank()).toList());
+        return join(join, inner.stream().filter(x -> !x.isBlank()).toList());
     }
 
     default boolean valueEquals(JsonNode previous, JsonNode next) {

--- a/src/main/java/dev/ebullient/convert/tools/JsonTextConverter.java
+++ b/src/main/java/dev/ebullient/convert/tools/JsonTextConverter.java
@@ -3,12 +3,10 @@ package dev.ebullient.convert.tools;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -83,10 +81,6 @@ public interface JsonTextConverter<T extends IndexType> {
             }
         }
         return x;
-    }
-
-    default boolean isPresent(String s) {
-        return s != null && !s.isBlank();
     }
 
     default String formatDice(String diceRoll) {
@@ -254,49 +248,6 @@ public interface JsonTextConverter<T extends IndexType> {
             return List.of();
         }
         return source::fieldNames;
-    }
-
-    default String join(String joiner, Collection<String> list) {
-        if (list == null || list.isEmpty()) {
-            return "";
-        }
-        return String.join(joiner, list).trim();
-    }
-
-    default String joinConjunct(String lastJoiner, List<String> list) {
-        return joinConjunct(list, ", ", lastJoiner, false);
-    }
-
-    default String joinConjunct(String joiner, String lastJoiner, List<String> list) {
-        return joinConjunct(list, joiner, lastJoiner, false);
-    }
-
-    default String joinConjunct(List<String> list, String joiner, String lastJoiner, boolean nonOxford) {
-        if (list == null || list.isEmpty()) {
-            return "";
-        }
-        if (list.size() == 1) {
-            return list.get(0);
-        }
-        if (list.size() == 2) {
-            return String.join(lastJoiner, list);
-        }
-
-        int pause = list.size() - 2;
-        StringBuilder out = new StringBuilder();
-        for (int i = 0; i < list.size(); ++i) {
-            out.append(list.get(i));
-
-            if (i < pause) {
-                out.append(joiner);
-            } else if (i == pause) {
-                if (!nonOxford) {
-                    out.append(joiner.trim());
-                }
-                out.append(lastJoiner);
-            }
-        }
-        return out.toString();
     }
 
     String linkify(T type, String s);
@@ -550,20 +501,6 @@ public interface JsonTextConverter<T extends IndexType> {
         }
         List<String> list = tui().readJsonValue(source, Tui.LIST_STRING);
         return list == null ? List.of() : list;
-    }
-
-    default String toTitleCase(String text) {
-        if (text == null || text.isEmpty()) {
-            return text;
-        }
-        return Arrays
-                .stream(text.split(" "))
-                .map(word -> word.isEmpty()
-                        ? word
-                        : Character.toTitleCase(word.charAt(0)) + word
-                                .substring(1)
-                                .toLowerCase())
-                .collect(Collectors.joining(" "));
     }
 
     enum SourceField implements JsonNodeReader {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -1,5 +1,9 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.isPresent;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.nio.file.Path;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
@@ -30,10 +34,6 @@ import dev.ebullient.convert.tools.dnd5e.qute.AcHp;
 import dev.ebullient.convert.tools.dnd5e.qute.ImmuneResist;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteNote;
-
-import static dev.ebullient.convert.StringUtil.isPresent;
-import static dev.ebullient.convert.StringUtil.joinConjunct;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteCommon implements JsonSource {
     static final Pattern featPattern = Pattern.compile("([^|]+)\\|?.*");
@@ -232,7 +232,7 @@ public class Json2QuteCommon implements JsonSource {
 
         var isComplex = multipleInner || multiMultipleInner || allValuesEqual == null;
         String joined = joinConjunct(
-            multiMultipleInner ? " - " : multipleInner ? "; " : ", ",
+                multiMultipleInner ? " - " : multipleInner ? "; " : ", ",
                 isComplex ? " OR " : " or ",
                 abilityOptions);
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import dev.ebullient.convert.StringUtil;
 import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.qute.ImageRef;
 import dev.ebullient.convert.qute.NamedText;
@@ -29,6 +30,10 @@ import dev.ebullient.convert.tools.dnd5e.qute.AcHp;
 import dev.ebullient.convert.tools.dnd5e.qute.ImmuneResist;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteNote;
+
+import static dev.ebullient.convert.StringUtil.isPresent;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteCommon implements JsonSource {
     static final Pattern featPattern = Pattern.compile("([^|]+)\\|?.*");
@@ -227,7 +232,7 @@ public class Json2QuteCommon implements JsonSource {
 
         var isComplex = multipleInner || multiMultipleInner || allValuesEqual == null;
         String joined = joinConjunct(
-                multiMultipleInner ? " - " : multipleInner ? "; " : ", ",
+            multiMultipleInner ? " - " : multipleInner ? "; " : ", ",
                 isComplex ? " OR " : " or ",
                 abilityOptions);
 
@@ -518,7 +523,7 @@ public class Json2QuteCommon implements JsonSource {
             }
 
             // remove empty values
-            values = values.stream().filter(x -> isPresent(x)).toList();
+            values = values.stream().filter(StringUtil::isPresent).toList();
 
             hasNote |= isPresent(note);
             String prereqs = String.join(

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteDeck.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteDeck.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -14,8 +16,6 @@ import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteDeck;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteDeck.Card;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteDeck extends Json2QuteCommon {
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteDeck.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteDeck.java
@@ -15,6 +15,8 @@ import dev.ebullient.convert.tools.dnd5e.qute.QuteDeck;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteDeck.Card;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteDeck extends Json2QuteCommon {
 
     Json2QuteDeck(Tools5eIndex index, Tools5eIndexType type, JsonNode jsonNode) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -17,8 +19,6 @@ import dev.ebullient.convert.tools.dnd5e.qute.QuteVehicle.ShipAcHp;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteVehicle.ShipCrewCargoPace;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteVehicle.ShipSection;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteVehicle extends Json2QuteCommon {
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteVehicle.java
@@ -18,6 +18,8 @@ import dev.ebullient.convert.tools.dnd5e.qute.QuteVehicle.ShipCrewCargoPace;
 import dev.ebullient.convert.tools.dnd5e.qute.QuteVehicle.ShipSection;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteVehicle extends Json2QuteCommon {
 
     final VehicleType vehicleType;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
@@ -1,5 +1,6 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.isPresent;
 import static java.util.Map.entry;
 
 import java.util.ArrayList;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -28,8 +30,6 @@ import dev.ebullient.convert.tools.JsonCopyException;
 import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteMonster.MonsterFields;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteRace.RaceFields;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class JsonSourceCopier implements JsonSource {
     static final List<String> GENERIC_WALKER_ENTRIES_KEY_BLOCKLIST = List.of("caption", "type", "colLabels", "colLabelGroups",

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
@@ -29,6 +29,8 @@ import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteMonster.MonsterFields;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteRace.RaceFields;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class JsonSourceCopier implements JsonSource {
     static final List<String> GENERIC_WALKER_ENTRIES_KEY_BLOCKLIST = List.of("caption", "type", "colLabels", "colLabelGroups",
             "name", "colStyles", "style", "shortName", "subclassShortName", "id", "path");

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
@@ -24,6 +24,8 @@ import dev.ebullient.convert.tools.ToolsIndex.TtrpgValue;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteItem.ItemFields;
 import dev.ebullient.convert.tools.dnd5e.Tools5eIndex.Tuple;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class MagicVariant implements JsonSource {
 
     static final List<String> IGNORE = List.of("entries", "rarity", "namePrefix", "nameSuffix");

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -23,8 +25,6 @@ import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.ToolsIndex.TtrpgValue;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteItem.ItemFields;
 import dev.ebullient.convert.tools.dnd5e.Tools5eIndex.Tuple;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class MagicVariant implements JsonSource {
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteVehicle.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteVehicle.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e.qute;
 
+import static dev.ebullient.convert.StringUtil.pluralize;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -174,7 +176,7 @@ public class QuteVehicle extends Tools5eQuteBase {
                 out.add("- **Hit Points** " + (isPresent(acHp.hp) ? acHp.hp : "\u2014"));
                 out.add("- **Damage Threshold** " + (isPresent(acHp.dt) ? acHp.dt : "\u2014"));
                 out.add("- **Speed** " + speedPace);
-                out.add("- **Cargo** " + (isPresent(cargo) ? cargo + makePlural(" ton", cargo) : "\u2014"));
+                out.add("- **Cargo** " + (isPresent(cargo) ? cargo + pluralize(" ton", cargo) : "\u2014"));
                 out.add("- **Crew** " + crewPresent);
                 out.add("- **Keel/Beam** " + (isPresent(keelBeam) ? keelBeam : "\u2014"));
                 out.add("- **Cost** " + (isPresent(acHp.cost) ? acHp.cost : "\u2014"));
@@ -185,7 +187,7 @@ public class QuteVehicle extends Tools5eQuteBase {
                         inner.add(crewPresent);
                     }
                     if (isPresent(passenger)) {
-                        inner.add(passenger + makePlural(" passenger", passenger));
+                        inner.add(passenger + pluralize(" passenger", passenger));
                     }
                     out.add("- **Creature Capacity** " + String.join(", ", inner));
                 }

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteVehicle.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteVehicle.java
@@ -176,7 +176,7 @@ public class QuteVehicle extends Tools5eQuteBase {
                 out.add("- **Hit Points** " + (isPresent(acHp.hp) ? acHp.hp : "\u2014"));
                 out.add("- **Damage Threshold** " + (isPresent(acHp.dt) ? acHp.dt : "\u2014"));
                 out.add("- **Speed** " + speedPace);
-                out.add("- **Cargo** " + (isPresent(cargo) ? cargo + pluralize(" ton", cargo) : "\u2014"));
+                out.add("- **Cargo** " + (isPresent(cargo) ? cargo + pluralize(" ton", cargo.equals("1") ? 1 : 2) : "\u2014"));
                 out.add("- **Crew** " + crewPresent);
                 out.add("- **Keel/Beam** " + (isPresent(keelBeam) ? keelBeam : "\u2014"));
                 out.add("- **Cost** " + (isPresent(acHp.cost) ? acHp.cost : "\u2014"));
@@ -187,7 +187,7 @@ public class QuteVehicle extends Tools5eQuteBase {
                         inner.add(crewPresent);
                     }
                     if (isPresent(passenger)) {
-                        inner.add(passenger + pluralize(" passenger", passenger));
+                        inner.add(passenger + pluralize(" passenger", passenger.equals("1") ? 1 : 2));
                     }
                     out.add("- **Creature Capacity** " + String.join(", ", inner));
                 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteAffliction.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteAffliction.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,8 +9,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.QuteAffliction;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteAffliction extends Json2QuteBase {
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteAffliction.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteAffliction.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.QuteAffliction;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteAffliction extends Json2QuteBase {
 
     public Json2QuteAffliction(Pf2eIndex index, Pf2eIndexType type, JsonNode rootNode) {

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBase.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBase.java
@@ -1,11 +1,7 @@
 package dev.ebullient.convert.tools.pf2e;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.JsonNode;
 
-import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteBase;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteNote;
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBook.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBook.java
@@ -14,6 +14,8 @@ import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteNote;
 import dev.ebullient.convert.tools.pf2e.qute.QuteBook;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteBook extends Json2QuteBase {
 
     final String bookRelativePath;

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBook.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteBook.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,8 +15,6 @@ import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteNote;
 import dev.ebullient.convert.tools.pf2e.qute.QuteBook;
 import io.quarkus.runtime.annotations.RegisterForReflection;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteBook extends Json2QuteBase {
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteDeity.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteDeity.java
@@ -1,5 +1,10 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.joiningConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -15,10 +20,6 @@ import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.QuteDeity;
 import io.quarkus.runtime.annotations.RegisterForReflection;
-
-import static dev.ebullient.convert.StringUtil.join;
-import static dev.ebullient.convert.StringUtil.joinConjunct;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteDeity extends Json2QuteBase {
 
@@ -194,10 +195,9 @@ public class Json2QuteDeity extends Json2QuteBase {
     }
 
     String commandmentToString(List<String> edictOrAnathema) {
-        if (edictOrAnathema.stream().anyMatch(x -> x.contains(","))) {
-            return String.join("; ", edictOrAnathema);
-        }
-        return String.join(", ", edictOrAnathema);
+        return String.join(
+                edictOrAnathema.stream().anyMatch(x -> x.contains(",")) ? "; " : ", ",
+                edictOrAnathema);
     }
 
     @RegisterForReflection
@@ -211,8 +211,7 @@ public class Json2QuteDeity extends Json2QuteBase {
             if (entry != null) {
                 return convert.replaceText(entry);
             }
-            return joinConjunct(" or ", abilities.stream()
-                    .map(StringUtil::toTitleCase).collect(Collectors.toList()));
+            return abilities.stream().map(StringUtil::toTitleCase).collect(joiningConjunct(" or "));
         }
 
         public String buildSkillString(JsonSource convert) {

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteDeity.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteDeity.java
@@ -8,12 +8,17 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import dev.ebullient.convert.StringUtil;
 import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.qute.NamedText;
 import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.QuteDeity;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteDeity extends Json2QuteBase {
 
@@ -206,8 +211,8 @@ public class Json2QuteDeity extends Json2QuteBase {
             if (entry != null) {
                 return convert.replaceText(entry);
             }
-            return convert.joinConjunct(" or ", abilities.stream()
-                    .map(convert::toTitleCase).collect(Collectors.toList()));
+            return joinConjunct(" or ", abilities.stream()
+                    .map(StringUtil::toTitleCase).collect(Collectors.toList()));
         }
 
         public String buildSkillString(JsonSource convert) {
@@ -215,7 +220,7 @@ public class Json2QuteDeity extends Json2QuteBase {
                 return convert.replaceText(entry);
             }
             return skills.stream()
-                    .map(s -> convert.linkify(Pf2eIndexType.spell, convert.toTitleCase(s)))
+                    .map(s -> convert.linkify(Pf2eIndexType.spell, toTitleCase(s)))
                     .collect(Collectors.joining(", "));
         }
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
@@ -21,6 +21,9 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemArmorData;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemShieldData;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemWeaponData;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteItem extends Json2QuteBase {
     static final String ITEM_TAG = "item";
 
@@ -295,7 +298,7 @@ public class Json2QuteItem extends Json2QuteBase {
         weaponData;
 
         String properName(Pf2eTypeReader convert) {
-            return convert.toTitleCase(this.nodeName());
+            return toTitleCase(this.nodeName());
         }
     }
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
@@ -1,5 +1,9 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.isPresent;
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -20,9 +24,6 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemActivate;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemArmorData;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemShieldData;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemWeaponData;
-
-import static dev.ebullient.convert.StringUtil.join;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteItem extends Json2QuteBase {
     static final String ITEM_TAG = "item";
@@ -254,7 +255,7 @@ public class Json2QuteItem extends Json2QuteBase {
     }
 
     private String penalty(String input, String suffix) {
-        if (input == null || input.isBlank() || "0".equals(input)) {
+        if (!isPresent(input) || "0".equals(input)) {
             return "—";
         }
         return (input.startsWith("-") ? input : ("-" + input)) + suffix;

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteItem.java
@@ -18,6 +18,7 @@ import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteBase;
 import dev.ebullient.convert.tools.pf2e.qute.QuteDataArmorClass;
+import dev.ebullient.convert.tools.pf2e.qute.QuteDataGenericStat.SimpleStat;
 import dev.ebullient.convert.tools.pf2e.qute.QuteDataHpHardnessBt;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemActivate;
@@ -109,7 +110,7 @@ public class Json2QuteItem extends Json2QuteBase {
                                 Pf2eItem.ac2.getIntFrom(shieldNode).orElse(null)),
                         new QuteDataHpHardnessBt(
                                 new QuteDataHpHardnessBt.HpStat(Pf2eItem.hp.getIntOrThrow(shieldNode)),
-                                new Pf2eSimpleStat(Pf2eItem.hardness.getIntOrThrow(shieldNode)),
+                                new SimpleStat(Pf2eItem.hardness.getIntOrThrow(shieldNode)),
                                 Pf2eItem.bt.getIntOrThrow(shieldNode)),
                         penalty(Pf2eItem.speedPen.getTextOrEmpty(shieldNode), " ft."));
     }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteRitual.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteRitual.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import dev.ebullient.convert.StringUtil;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteBase;
 import dev.ebullient.convert.tools.pf2e.qute.QuteRitual;
@@ -122,7 +123,7 @@ public class Json2QuteRitual extends Json2QuteSpell {
                 return convert.replaceText(entry);
             }
             return String.format("%s (%s%s)", skillsToString(convert), prof,
-                    mustBe == null ? "" : String.format("; you must be a %s", convert.joinConjunct(" or ", mustBe)));
+                    mustBe == null ? "" : String.format("; you must be a %s", StringUtil.joinConjunct(" or ", mustBe)));
         }
 
         public String buildSecondaryString(JsonSource convert) {
@@ -138,7 +139,7 @@ public class Json2QuteRitual extends Json2QuteSpell {
             List<String> converted = skills.stream()
                     .map(s -> convert.linkify(Pf2eIndexType.skill, s))
                     .collect(Collectors.toList());
-            return convert.joinConjunct(" or ", converted);
+            return StringUtil.joinConjunct(" or ", converted);
         }
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteRitual.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteRitual.java
@@ -15,6 +15,8 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteRitual.QuteRitualChecks;
 import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellTarget;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+
 public class Json2QuteRitual extends Json2QuteSpell {
     static final String RITUAL_TAG = "ritual";
 
@@ -123,7 +125,7 @@ public class Json2QuteRitual extends Json2QuteSpell {
                 return convert.replaceText(entry);
             }
             return String.format("%s (%s%s)", skillsToString(convert), prof,
-                    mustBe == null ? "" : String.format("; you must be a %s", StringUtil.joinConjunct(" or ", mustBe)));
+                    mustBe == null ? "" : String.format("; you must be a %s", joinConjunct(" or ", mustBe)));
         }
 
         public String buildSecondaryString(JsonSource convert) {
@@ -139,7 +141,7 @@ public class Json2QuteRitual extends Json2QuteSpell {
             List<String> converted = skills.stream()
                     .map(s -> convert.linkify(Pf2eIndexType.skill, s))
                     .collect(Collectors.toList());
-            return StringUtil.joinConjunct(" or ", converted);
+            return joinConjunct(" or ", converted);
         }
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteSpell.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteSpell.java
@@ -1,5 +1,8 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -17,9 +20,6 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellCasting;
 import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellSaveDuration;
 import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellTarget;
 import io.quarkus.runtime.annotations.RegisterForReflection;
-
-import static dev.ebullient.convert.StringUtil.join;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public class Json2QuteSpell extends Json2QuteBase {
     static final String SPELL_TAG = "spell";

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteSpell.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteSpell.java
@@ -18,6 +18,9 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellSaveDuration;
 import dev.ebullient.convert.tools.pf2e.qute.QuteSpell.QuteSpellTarget;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public class Json2QuteSpell extends Json2QuteBase {
     static final String SPELL_TAG = "spell";
 
@@ -121,7 +124,7 @@ public class Json2QuteSpell extends Json2QuteBase {
         boolean hidden = Pf2eSpell.hidden.booleanOrDefault(savingThrow, false);
         String throwString = Pf2eSpell.type.getListOfStrings(savingThrow, tui())
                 .stream()
-                .map(t -> Pf2eSavingThrowType.valueFromEncoding(t))
+                .map(Pf2eSavingThrowType::valueFromEncoding)
                 .map(t -> toTitleCase(t.name()))
                 .collect(Collectors.joining(" or "));
         if (!hidden && !throwString.isEmpty()) {

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteTable.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteTable.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteNote;
 
+import static dev.ebullient.convert.StringUtil.join;
+
 public class Json2QuteTable extends Json2QuteBase {
 
     public Json2QuteTable(Pf2eIndex index, JsonNode rootNode) {

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteTable.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Json2QuteTable.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.join;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,8 +10,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import dev.ebullient.convert.tools.Tags;
 import dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteNote;
-
-import static dev.ebullient.convert.StringUtil.join;
 
 public class Json2QuteTable extends Json2QuteBase {
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/JsonSource.java
@@ -24,6 +24,9 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAffliction;
 import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAffliction.QuteAfflictionStage;
 import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public interface JsonSource extends JsonTextReplacement {
 
     /**
@@ -698,7 +701,7 @@ public interface JsonSource extends JsonTextReplacement {
         types;
 
         public static QuteInlineAttack createInlineAttack(JsonNode node, JsonSource convert) {
-            String name = convert.toTitleCase(SourceField.name.replaceTextFrom(node, convert));
+            String name = toTitleCase(SourceField.name.replaceTextFrom(node, convert));
 
             Tags tags = new Tags();
             Collection<String> traits = convert.collectTraitsFrom(node, tags);

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/JsonSource.java
@@ -1,5 +1,8 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -23,9 +26,6 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteDataActivity;
 import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAffliction;
 import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAffliction.QuteAfflictionStage;
 import dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack;
-
-import static dev.ebullient.convert.StringUtil.join;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public interface JsonSource extends JsonTextReplacement {
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/JsonTextReplacement.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/JsonTextReplacement.java
@@ -12,6 +12,8 @@ import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.JsonTextConverter;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public interface JsonTextReplacement extends JsonTextConverter<Pf2eIndexType> {
 
     enum Field implements JsonNodeReader {

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/JsonTextReplacement.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/JsonTextReplacement.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.pf2e;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.MatchResult;
@@ -11,8 +13,6 @@ import dev.ebullient.convert.config.CompendiumConfig;
 import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.JsonTextConverter;
-
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 public interface JsonTextReplacement extends JsonTextConverter<Pf2eIndexType> {
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eTypeReader.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eTypeReader.java
@@ -28,6 +28,8 @@ import dev.ebullient.convert.tools.pf2e.qute.QuteDataSpeed;
 import dev.ebullient.convert.tools.pf2e.qute.QuteItem.QuteItemWeaponData;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 public interface Pf2eTypeReader extends JsonSource {
 
     enum Pf2eAction implements JsonNodeReader {
@@ -314,11 +316,11 @@ public interface Pf2eTypeReader extends JsonSource {
                             continue;
                         }
                         int value = extra.getValue().asInt();
-                        svt.savingThrows.put(convert.toTitleCase(extra.getKey()),
+                        svt.savingThrows.put(toTitleCase(extra.getKey()),
                                 (value >= 0 ? "+" : "") + value);
                     }
                 }
-                svt.savingThrows.put(convert.toTitleCase(e.getKey()),
+                svt.savingThrows.put(toTitleCase(e.getKey()),
                         String.join(", ", svValue));
             }
             svt.abilities = convert.replaceText(abilities.getTextOrNull(stNode));

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteCreature.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteCreature.java
@@ -1,12 +1,12 @@
 package dev.ebullient.convert.tools.pf2e.qute;
 
+import static dev.ebullient.convert.StringUtil.flatJoin;
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.parenthesize;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import dev.ebullient.convert.qute.QuteUtil;
 import dev.ebullient.convert.tools.Tags;
@@ -96,13 +96,7 @@ public class QuteCreature extends Pf2eQuteBase {
 
         @Override
         public String toString() {
-            return Stream.of(
-                    languages != null ? List.of(String.join(", ", languages)) : List.<String> of(),
-                    abilities, notes)
-                    .filter(Objects::nonNull)
-                    .flatMap(Collection::stream)
-                    .dropWhile(String::isEmpty)
-                    .collect(Collectors.joining("; "));
+            return flatJoin("; ", List.of(join(", ", languages)), abilities, notes);
         }
     }
 
@@ -125,8 +119,7 @@ public class QuteCreature extends Pf2eQuteBase {
 
         @Override
         public String toString() {
-            return skills.stream().map(QuteDataSkillBonus::toString).collect(Collectors.joining(", ")) +
-                    (notes == null ? "" : " " + String.join("; ", notes));
+            return join(" ", join(", ", skills), join("; ", notes));
         }
     }
 
@@ -142,14 +135,7 @@ public class QuteCreature extends Pf2eQuteBase {
 
         @Override
         public String toString() {
-            StringJoiner s = new StringJoiner(" ").add(name);
-            if (type != null) {
-                s.add(String.format("(%s)", type));
-            }
-            if (range != null) {
-                s.add(range.toString());
-            }
-            return s.toString();
+            return join(" ", name, parenthesize(type), range);
         }
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataArmorClass.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataArmorClass.java
@@ -8,7 +8,6 @@ import static dev.ebullient.convert.StringUtil.parenthesize;
 import java.util.List;
 import java.util.Map;
 
-import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat;
 import io.quarkus.qute.TemplateData;
 
 /**
@@ -25,7 +24,7 @@ import io.quarkus.qute.TemplateData;
 @TemplateData
 public record QuteDataArmorClass(
         Integer value, Map<String, Integer> alternateValues, List<String> notes,
-        List<String> abilities) implements Pf2eStat {
+        List<String> abilities) implements QuteDataGenericStat {
 
     public QuteDataArmorClass(Integer value) {
         this(value, Map.of(), List.of(), List.of());
@@ -47,7 +46,7 @@ public record QuteDataArmorClass(
 
     @Override
     public String bonus() {
-        return join(" ", Pf2eStat.super.bonus(), formattedAlternates(true));
+        return join(" ", QuteDataGenericStat.super.bonus(), formattedAlternates(true));
     }
 
     @Override

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataGenericStat.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataGenericStat.java
@@ -1,0 +1,49 @@
+package dev.ebullient.convert.tools.pf2e.qute;
+
+import dev.ebullient.convert.StringUtil;
+import dev.ebullient.convert.qute.QuteUtil;
+
+import java.util.List;
+
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.joiningNonEmpty;
+
+/** A generic container for a PF2e stat value which may have an attached note. */
+public interface QuteDataGenericStat extends QuteUtil {
+    /** Returns the value of the stat. */
+    Integer value();
+
+    /** Returns any notes associated with this value. */
+    List<String> notes();
+
+    /** Return the value formatted with a leading +/-. */
+    default String bonus() {
+        return "%+d".formatted(value());
+    }
+
+    /** Return notes formatted as space-delimited parenthesized strings. */
+    default String formattedNotes() {
+        return notes().stream().map(StringUtil::parenthesize).collect(joiningNonEmpty(" "));
+    }
+
+    /**
+     * A basic {@link QuteDataGenericStat} which provides only a value and possibly a note. Default representation:
+     * <blockquote>
+     * 10 (some note) (some other note)
+     * </blockquote>
+     */
+    record SimpleStat(Integer value, List<String> notes) implements QuteDataGenericStat {
+        public SimpleStat(Integer value) {
+            this(value, List.of());
+        }
+
+        public SimpleStat(Integer value, String note) {
+            this(value, note == null || note.isBlank() ? List.of() : List.of(note));
+        }
+
+        @Override
+        public String toString() {
+            return join(" ", value.toString(), formattedNotes());
+        }
+    }
+}

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataGenericStat.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataGenericStat.java
@@ -27,7 +27,9 @@ public interface QuteDataGenericStat extends QuteUtil {
     }
 
     /**
-     * A basic {@link QuteDataGenericStat} which provides only a value and possibly a note. Default representation:
+     * A basic {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataGenericStat QuteDataGenericStat} which provides
+     * only a value and possibly a note. Default representation:
+     *
      * <blockquote>
      * 10 (some note) (some other note)
      * </blockquote>

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataHpHardnessBt.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataHpHardnessBt.java
@@ -2,14 +2,13 @@ package dev.ebullient.convert.tools.pf2e.qute;
 
 import static dev.ebullient.convert.StringUtil.flatJoin;
 import static dev.ebullient.convert.StringUtil.join;
-import static dev.ebullient.convert.StringUtil.joinWithPrefix;
 
 import java.util.List;
 import java.util.StringJoiner;
 
 import dev.ebullient.convert.StringUtil;
 import dev.ebullient.convert.qute.QuteUtil;
-import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat;
+import dev.ebullient.convert.tools.pf2e.qute.QuteDataGenericStat.SimpleStat;
 import io.quarkus.qute.TemplateData;
 
 /**
@@ -31,11 +30,12 @@ import io.quarkus.qute.TemplateData;
  * <blockquote><b>Head Hardness</b> 10, <b>Head HP</b> 30 (hydra regeneration)</blockquote>
  *
  * @param hp The HP as a {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataHpHardnessBt.HpStat HpStat} (optional)
- * @param hardness Hardness as a {@link dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat Pf2eStat} (optional)
+ * @param hardness Hardness as a {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataGenericStat.SimpleStat SimpleStat}
+ *        (optional)
  * @param brokenThreshold Broken threshold as an integer (optional, not populated for creatures)
  */
 @TemplateData
-public record QuteDataHpHardnessBt(HpStat hp, Pf2eStat hardness, Integer brokenThreshold) implements QuteUtil {
+public record QuteDataHpHardnessBt(HpStat hp, SimpleStat hardness, Integer brokenThreshold) implements QuteUtil {
 
     @Override
     public String toString() {
@@ -73,7 +73,7 @@ public record QuteDataHpHardnessBt(HpStat hp, Pf2eStat hardness, Integer brokenT
      * @param notes Any notes associated with the HP.
      */
     @TemplateData
-    public record HpStat(Integer value, List<String> notes, List<String> abilities) implements Pf2eStat {
+    public record HpStat(Integer value, List<String> notes, List<String> abilities) implements QuteDataGenericStat {
         public HpStat(Integer value) {
             this(value, null);
         }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSkillBonus.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSkillBonus.java
@@ -7,7 +7,6 @@ import static dev.ebullient.convert.StringUtil.formatMap;
 import java.util.List;
 import java.util.Map;
 
-import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader;
 import io.quarkus.qute.TemplateData;
 
 /**
@@ -27,7 +26,7 @@ import io.quarkus.qute.TemplateData;
 @TemplateData
 public record QuteDataSkillBonus(
         String name, Integer value, Map<String, Integer> otherBonuses,
-        List<String> notes) implements Pf2eTypeReader.Pf2eStat {
+        List<String> notes) implements QuteDataGenericStat {
 
     public QuteDataSkillBonus(String name, Integer standardBonus) {
         this(name, standardBonus, Map.of(), List.of());
@@ -37,7 +36,7 @@ public record QuteDataSkillBonus(
     @Override
     public String bonus() {
         return flatJoin(" ",
-                List.of(Pf2eTypeReader.Pf2eStat.super.bonus()),
+                List.of(QuteDataGenericStat.super.bonus()),
                 formatMap(otherBonuses, (k, v) -> "(%+d %s)".formatted(v, k)));
     }
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSkillBonus.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSkillBonus.java
@@ -1,9 +1,11 @@
 package dev.ebullient.convert.tools.pf2e.qute;
 
+import static dev.ebullient.convert.StringUtil.flatJoin;
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.formatMap;
+
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader;
 import io.quarkus.qute.TemplateData;
@@ -24,9 +26,7 @@ import io.quarkus.qute.TemplateData;
  */
 @TemplateData
 public record QuteDataSkillBonus(
-        String name,
-        Integer value,
-        Map<String, Integer> otherBonuses,
+        String name, Integer value, Map<String, Integer> otherBonuses,
         List<String> notes) implements Pf2eTypeReader.Pf2eStat {
 
     public QuteDataSkillBonus(String name, Integer standardBonus) {
@@ -36,14 +36,13 @@ public record QuteDataSkillBonus(
     /** Return the standard bonus and any other conditional bonuses. */
     @Override
     public String bonus() {
-        return Stream.concat(
-                Stream.of(Pf2eTypeReader.Pf2eStat.super.bonus()),
-                otherBonuses.entrySet().stream().map(e -> String.format("(%+d %s)", e.getValue(), e.getKey())))
-                .collect(Collectors.joining(" "));
+        return flatJoin(" ",
+                List.of(Pf2eTypeReader.Pf2eStat.super.bonus()),
+                formatMap(otherBonuses, (k, v) -> "(%+d %s)".formatted(v, k)));
     }
 
     @Override
     public String toString() {
-        return String.join(" ", name, bonus(), formattedNotes()).trim();
+        return join(" ", name, bonus(), formattedNotes());
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSpeed.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSpeed.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat;
-
 /**
  *
  * @param value The land speed in feet
@@ -19,7 +17,7 @@ import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat;
  */
 public record QuteDataSpeed(
         Integer value, Map<String, Integer> otherSpeeds, List<String> notes,
-        List<String> abilities) implements Pf2eStat {
+        List<String> abilities) implements QuteDataGenericStat {
 
     public void addAbility(String ability) {
         abilities.add(ability);
@@ -28,7 +26,7 @@ public record QuteDataSpeed(
     /** Return formatted notes and abilities. e.g. {@code (note) (another note); ability, another ability} */
     @Override
     public String formattedNotes() {
-        return join("; ", Pf2eStat.super.formattedNotes(), join(", ", abilities));
+        return join("; ", QuteDataGenericStat.super.formattedNotes(), join(", ", abilities));
     }
 
     /** Return formatted speeds as a string, starting with land speed. e.g. {@code 10 feet, swim 20 feet} */

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSpeed.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDataSpeed.java
@@ -1,13 +1,14 @@
 package dev.ebullient.convert.tools.pf2e.qute;
 
-import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader;
+import static dev.ebullient.convert.StringUtil.flatJoin;
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.formatMap;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import dev.ebullient.convert.tools.pf2e.Pf2eTypeReader.Pf2eStat;
 
 /**
  *
@@ -18,7 +19,7 @@ import java.util.stream.Stream;
  */
 public record QuteDataSpeed(
         Integer value, Map<String, Integer> otherSpeeds, List<String> notes,
-        List<String> abilities) implements Pf2eTypeReader.Pf2eStat {
+        List<String> abilities) implements Pf2eStat {
 
     public void addAbility(String ability) {
         abilities.add(ability);
@@ -27,19 +28,14 @@ public record QuteDataSpeed(
     /** Return formatted notes and abilities. e.g. {@code (note) (another note); ability, another ability} */
     @Override
     public String formattedNotes() {
-        return Stream.of(Pf2eTypeReader.Pf2eStat.super.formattedNotes(), String.join(", ", abilities))
-                .filter(this::isPresent)
-                .collect(Collectors.joining("; "));
+        return join("; ", Pf2eStat.super.formattedNotes(), join(", ", abilities));
     }
 
     /** Return formatted speeds as a string, starting with land speed. e.g. {@code 10 feet, swim 20 feet} */
     public String formattedSpeeds() {
-        StringJoiner speeds = new StringJoiner(", ")
-                .add(Optional.ofNullable(value).map(n -> String.format("%d feet", value)).orElse("no land speed"));
-        otherSpeeds.entrySet().stream()
-                .map(e -> String.format("%s %d feet", e.getKey(), e.getValue()))
-                .forEach(speeds::add);
-        return speeds.toString();
+        return flatJoin(", ",
+                List.of(Optional.ofNullable(value).map("%d feet"::formatted).orElse("no land speed")),
+                formatMap(otherSpeeds, "%s %d feet"::formatted));
     }
 
     /**
@@ -54,7 +50,6 @@ public record QuteDataSpeed(
      */
     @Override
     public String toString() {
-        return Stream.of(formattedSpeeds(), formattedNotes())
-                .filter(this::isPresent).collect(Collectors.joining(notes.isEmpty() ? ", " : " "));
+        return join(notes.isEmpty() ? ", " : " ", formattedSpeeds(), formattedNotes());
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDeity.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteDeity.java
@@ -1,13 +1,15 @@
 package dev.ebullient.convert.tools.pf2e.qute;
 
+import static dev.ebullient.convert.StringUtil.flatJoin;
+import static dev.ebullient.convert.StringUtil.join;
+import static dev.ebullient.convert.StringUtil.joinWithPrefix;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import dev.ebullient.convert.qute.NamedText;
 import dev.ebullient.convert.qute.QuteUtil;
@@ -159,13 +161,8 @@ public class QuteDeity extends Pf2eQuteBase {
         @Override
         public String toString() {
             String speedText = speed == null ? ""
-                    : "Speed %s%s".formatted(speed.formattedSpeeds(),
-                            speed.formattedNotes().isEmpty() ? "" : (", " + speed.formattedNotes()));
-            return "**" + name + "** " + Stream.of(List.of(speedText, shield), melee, ranged, ability)
-                    .flatMap(Collection::stream)
-                    .filter(this::isPresent)
-                    .map(Object::toString)
-                    .collect(Collectors.joining("; "));
+                    : join(", ", "Speed %s".formatted(speed.formattedSpeeds()), speed.formattedNotes());
+            return "**" + name + "** " + flatJoin("; ", List.of(speedText, shield), melee, ranged, ability);
         }
     }
 
@@ -189,10 +186,9 @@ public class QuteDeity extends Pf2eQuteBase {
         public String note;
 
         public String toString() {
-            StringJoiner traitText = new StringJoiner(", ", " (", ")").setEmptyValue("");
-            traits.stream().filter(this::isPresent).forEach(traitText::add);
             return "**%s**: %s %s%s, **Damage** %s %s".formatted(
-                    actionType, activityType, name, traitText, damage, Optional.ofNullable(note).orElse("")).trim();
+                    actionType, activityType, name, joinWithPrefix(", ", traits, " (", ")"),
+                    damage, Optional.ofNullable(note).orElse("")).trim();
         }
     }
 
@@ -211,7 +207,7 @@ public class QuteDeity extends Pf2eQuteBase {
         public String text;
 
         public String toString() {
-            return String.format("**%s**: %s", name, text);
+            return "**%s**: %s".formatted(name, text);
         }
     }
 


### PR DESCRIPTION
I've added a StringUtil helper with what I hope is a very clear scope - only string-related methods, and only methods which don't require any domain-specific knowledge. I've also changed some of the previous code I've written (and adjacent) to use these helpers. This actually incidentally resulted in a few fixed bugs (see second commit).

The first commit is mostly just IntelliJ refactors, moving existing methods into StringUtil. The second commit adds some new helpers and modifies some of the behavior of the existing helpers to make them more widely applicable. I know this is a bit far reaching, so for the second commit I've done an extra testing step of diffing the before/after changes (see that commit message for details), and aside from the fixed bugs there aren't any output changes.

Sorry if I went a bit overboard with the Collector 😅. I just really like streams.