### PR TITLE
Allow unqualified names in Javadoc without making MarkdownDoclet mad

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteCreature.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteCreature.java
@@ -20,7 +20,7 @@ import io.quarkus.qute.TemplateData;
  * other leading content only appropriate to the standalone case).
  * </p>
  * <p>
- * Extension of {@link dev.ebullient.convert.tools.pf2e.qute.Pf2eQuteBase Pf2eQuteBase}
+ * Extension of {@link Pf2eQuteBase Pf2eQuteBase}
  * </p>
  */
 @TemplateData
@@ -37,29 +37,29 @@ public class QuteCreature extends Pf2eQuteBase {
     /** Creature perception (number, optional) */
     public final Integer perception;
     /**
-     * Languages as {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureLanguages CreatureLanguages}
+     * Languages as {@link QuteCreature.CreatureLanguages CreatureLanguages}
      */
     public final CreatureLanguages languages;
-    /** Defenses (AC, saves, etc) as {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataDefenses QuteDataDefenses} */
+    /** Defenses (AC, saves, etc) as {@link QuteDataDefenses QuteDataDefenses} */
     public final QuteDataDefenses defenses;
     /**
-     * Skill bonuses as {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureSkills CreatureSkills}
+     * Skill bonuses as {@link QuteCreature.CreatureSkills CreatureSkills}
      */
     public final CreatureSkills skills;
-    /** Senses as a list of {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureSense CreatureSense} */
+    /** Senses as a list of {@link QuteCreature.CreatureSense CreatureSense} */
     public final List<CreatureSense> senses;
     /** Ability modifiers as a map of (name, modifier) */
     public final Map<String, Integer> abilityMods;
     /** Items held by the creature as a list of strings */
     public final List<String> items;
-    /** The creature's speed, as an {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataSpeed QuteDataSpeed} */
+    /** The creature's speed, as an {@link QuteDataSpeed QuteDataSpeed} */
     public final QuteDataSpeed speed;
-    /** The creature's attacks, as a list of {@link dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack QuteInlineAttack} */
+    /** The creature's attacks, as a list of {@link QuteInlineAttack QuteInlineAttack} */
     public final List<QuteInlineAttack> attacks;
 
     /**
      * The creature's abilities, as a
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureAbilities CreatureAbilities}.
+     * {@link QuteCreature.CreatureAbilities CreatureAbilities}.
      */
     public final CreatureAbilities abilities;
 
@@ -118,7 +118,7 @@ public class QuteCreature extends Pf2eQuteBase {
      * </blockquote>
      *
      * @param skills Skill bonuses for the creature, as a list of
-     *        {@link dev.ebullient.convert.tools.pf2e.qute.QuteDataSkillBonus QuteDataSkillBonus}
+     *        {@link QuteDataSkillBonus QuteDataSkillBonus}
      * @param notes Notes for the creature's skills (list of strings, optional)
      */
     @TemplateData
@@ -153,13 +153,13 @@ public class QuteCreature extends Pf2eQuteBase {
 
     /**
      * A creature's abilities, split into the section of the statblock where they should be displayed. Each section is
-     * a list of {@link dev.ebullient.convert.tools.pf2e.qute.QuteAbilityOrAffliction QuteAbilityOrAffliction}. Use
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureAbilities#formattedTop() formattedTop},
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureAbilities#formattedTop() formattedMiddle}, and
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteCreature.CreatureAbilities#formattedTop() formattedBottom} to
+     * a list of {@link QuteAbilityOrAffliction QuteAbilityOrAffliction}. Use
+     * {@link QuteCreature.CreatureAbilities#formattedTop() formattedTop},
+     * {@link QuteCreature.CreatureAbilities#formattedTop() formattedMiddle}, and
+     * {@link QuteCreature.CreatureAbilities#formattedTop() formattedBottom} to
      * get pre-formatted abilities according to the templates defined for
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteAbility QuteAbility} or
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteAffliction QuteAffliction}.
+     * {@link QuteAbility QuteAbility} or
+     * {@link QuteAffliction QuteAffliction}.
      *
      * @param top Abilities which should be displayed in the top section of the statblock
      * @param middle Abilities which should be displayed in the middle section of the statblock

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteInlineAttack.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/qute/QuteInlineAttack.java
@@ -24,11 +24,11 @@ public final class QuteInlineAttack implements QuteDataGenericStat, QuteUtil.Ren
     /** The name of the attack e.g. "fist" (string) */
     public final String name;
 
-    /** Number/type of action cost ({@link dev.ebullient.convert.tools.pf2e.qute.QuteDataActivity QuteDataActivity}) */
+    /** Number/type of action cost ({@link QuteDataActivity QuteDataActivity}) */
     public final QuteDataActivity activity;
 
     /**
-     * The range of the attack ({@link dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack.AttackRangeType AttackType} enum)
+     * The range of the attack ({@link QuteInlineAttack.AttackRangeType AttackRangeType} enum)
      */
     public final AttackRangeType rangeType;
 
@@ -43,8 +43,8 @@ public final class QuteInlineAttack implements QuteDataGenericStat, QuteUtil.Ren
 
     /**
      * The damage types caused by the attack. Will be included in either
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack#damage damage} or in
-     * {@link dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack#multilineEffect multilineEffect}.
+     * {@link QuteInlineAttack#damage damage} or in
+     * {@link QuteInlineAttack#multilineEffect multilineEffect}.
      */
     public final Collection<String> damageTypes;
 
@@ -53,7 +53,7 @@ public final class QuteInlineAttack implements QuteDataGenericStat, QuteUtil.Ren
 
     /**
      * Any additional effects associated with the attack e.g. grab (list of strings). Effects listed here
-     * may be repeated in {@link dev.ebullient.convert.tools.pf2e.qute.QuteInlineAttack#damage damage}.
+     * may be repeated in {@link QuteInlineAttack#damage damage}.
      */
     public final List<String> effects;
 


### PR DESCRIPTION
This is an attempt to allow unqualified names in Javadoc while maintaining the linking and organization of Markdown notes. I've tried to do this in a way that's minimally brittle, and also doesn't balloon out the compile time of these docs.

Currently, it tries all the included packages (`dev.ebullient.convert.qute`, `dev.ebullient.convert.tools.dnd5e.qute` and `dev.ebullient.convert.tools.pf2e.qute`) as the qualified name, and uses it as the qualified name if and only if it's a unique match. This means that only unique class names can be used unqualified, but I can't find a better way of doing this - I can't see any way to access the imports in the file to use that to tell which class is being referenced.

This includes changing some docs to use unqualified names just to test out that it actually works. I've generated the docs locally to test myself of course but I'm on Windows at the moment, so the line breaks and path separators are wrong, which is why I haven't included it.

(This PR is branched off of PR #458  - apologies for the messy diff)