### PR TITLE
Implement JsonSourceCopier functionality for Pf2e

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/IndexType.java
+++ b/src/main/java/dev/ebullient/convert/tools/IndexType.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface IndexType {
 
     String name();
@@ -7,4 +9,10 @@ public interface IndexType {
     String templateName();
 
     String defaultSourceString();
+
+    /** Return a key which can be used to look up the given node of this type from the index. */
+    String createKey(JsonNode key);
+
+    /** As {@link #createKey(JsonNode)}, but use the given name and source instead of retrieving it from the node. */
+    String createKey(String name, String source);
 }

--- a/src/main/java/dev/ebullient/convert/tools/JsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/JsonSourceCopier.java
@@ -1,0 +1,815 @@
+package dev.ebullient.convert.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import dev.ebullient.convert.io.Tui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNullElse;
+
+public abstract class JsonSourceCopier<T extends IndexType> implements JsonTextConverter<T> {
+    static final List<String> GENERIC_WALKER_ENTRIES_KEY_BLOCKLIST = List.of(
+        "caption", "type", "colLabels", "colLabelGroups",
+        "name", "colStyles", "style", "shortName", "subclassShortName", "id", "path");
+
+    static final List<String> _MERGE_REQUIRES_PRESERVE_BASE = List.of(
+            "_versions",
+            "basicRules",
+            "hasFluff",
+            "hasFluffImages",
+            "hasToken",
+            "indexInputType", // mine: do I have the usage right?
+            "indexKey", // mine: do I have the usage right?
+            "otherSources",
+            "page",
+            "reprintedAs",
+            "srd");
+    static final List<String> COPY_ENTRY_PROPS = List.of(
+            "action", "bonus", "reaction", "trait", "legendary", "mythic", "variant", "spellcasting",
+            "actionHeader", "bonusHeader", "reactionHeader", "legendaryHeader", "mythicHeader");
+
+    static final Pattern variable_subst = Pattern.compile("<\\$(?<variable>[^$]+)\\$>");
+
+    static boolean metaPreserveKey(JsonNode _preserve, String key) {
+        return _preserve != null && (_preserve.has("*") || _preserve.has(key));
+    }
+
+    protected boolean mergePreserveKey(T type, String key) {
+        return _MERGE_REQUIRES_PRESERVE_BASE.contains(key);
+    }
+
+    protected abstract JsonNode getOriginNode(String key);
+
+    public JsonNode handleCopy(T type, JsonNode copyTo) {
+        String copyToKey = type.createKey(copyTo);
+        JsonNode _copy = MetaFields._copy.getFrom(copyTo);
+        if (_copy != null) {
+            String copyFromKey = type.createKey(_copy);
+            JsonNode copyFrom = getOriginNode(copyFromKey);
+            if (copyToKey.equals(copyFromKey)) {
+                tui().errorf("Error (%s): Self-referencing copy. This is a data entry error. %s", copyToKey, _copy);
+                return copyTo;
+            }
+            if (copyFrom == null) {
+                tui().errorf("Error (%s): Unable to find source for %s", copyToKey, copyFromKey);
+                return copyTo;
+            }
+            // is the copy a copy?
+            copyFrom = handleCopy(type, copyFrom);
+            try {
+                copyTo = mergeNodes(type, copyToKey, copyFrom, copyTo);
+            } catch (JsonCopyException | StackOverflowError | UnsupportedOperationException e) {
+                tui().errorf(e, "Error (%s): Unable to merge nodes. CopyTo: %s, CopyFrom: %s", copyToKey, copyTo, copyFrom);
+            }
+        }
+        return copyTo;
+    }
+
+    protected abstract String getExternalTemplateKey(JsonNode trait);
+
+    // 	utils.js: static getCopy (impl, copyFrom, copyTo, templateData,...) {
+    JsonNode mergeNodes(T type, String originKey, JsonNode copyFrom, JsonNode copyTo) {
+        // edit in place: if you don't, lower-level copies will keep being revisted.
+        ObjectNode target = (ObjectNode) copyTo;
+
+        JsonNode _copy = MetaFields._copy.getFrom(copyTo);
+        JsonNode _mod = _copy == null ? null : normalizeMods(MetaFields._mod.getFrom(_copy));
+        JsonNode _trait = _copy == null ? null : MetaFields._trait.getFrom(_copy);
+
+        JsonNode templateApplyRoot = null;
+
+        if (_trait != null) {
+            // fetch and apply external template mods
+            String templateKey = getExternalTemplateKey(_trait);
+            JsonNode template = getOriginNode(templateKey);
+            if (template == null) {
+                tui().warn("Unable to find trait for " + templateKey);
+            } else {
+                template = copyNode(template); // copy fast
+
+                JsonNode apply = MetaFields.apply.getFrom(template);
+                templateApplyRoot = MetaFields._root.getFrom(apply);
+
+                JsonNode templateMods = normalizeMods(MetaFields._mod.getFrom(apply));
+                if (templateMods != null) {
+                    if (_mod == null) {
+                        _mod = templateMods;
+                    } else {
+                        ObjectNode _modRw = (ObjectNode) _mod;
+                        for (Entry<String, JsonNode> e : iterableFields(templateMods)) {
+                            if (_modRw.has(e.getKey())) {
+                                appendToArray(_modRw.withArray(e.getKey()), e.getValue());
+                            } else {
+                                _modRw.set(e.getKey(), e.getValue());
+                            }
+                        }
+                    }
+                }
+            }
+            MetaFields._trait.removeFrom(_copy);
+        }
+
+        JsonNode _preserve = _copy == null
+                ? mapper().createObjectNode()
+                : MetaFields._preserve.getFrom(_copy);
+
+        // Copy required values from...
+        for (Entry<String, JsonNode> from : iterableFields(copyFrom)) {
+            String k = from.getKey();
+            JsonNode copyToField = copyTo.get(k);
+            if (copyToField != null && copyToField.isNull()) {
+                // copyToField exists as `null`. Remove the field.
+                target.remove(k);
+                continue;
+            }
+            if (copyToField == null) {
+                // not already present in copyTo -- should we copyFrom?
+                // Do merge rules indicate the value should be preserved
+                if (mergePreserveKey(type, k)) {
+                    // Does metadata indicate that it should be copied?
+                    if (metaPreserveKey(_preserve, k)) {
+                        target.set(k, copyNode(from.getValue()));
+                    }
+                } else {
+                    // in general, yes.
+                    target.set(k, copyNode(from.getValue()));
+                }
+            }
+        }
+
+        // Apply template _root properties
+        List<String> copyToRootProps = streamOfFieldNames(copyTo).toList();
+        if (templateApplyRoot != null) {
+            for (Entry<String, JsonNode> from : iterableFields(templateApplyRoot)) {
+                String k = from.getKey();
+                if (!copyToRootProps.contains(k)) {
+                    continue; // avoid overwriting any real properties with templates
+                }
+                target.set(k, copyNode(from.getValue()));
+            }
+        }
+
+        // Apply mods
+        if (_mod != null) {
+            for (Entry<String, JsonNode> entry : iterableFields(_mod)) {
+                // use the copyTo value as the attribute source for resolving dynamic text
+                entry.setValue(resolveDynamicText(originKey, entry.getValue(), copyTo));
+            }
+
+            for (Entry<String, JsonNode> entry : iterableFields(_mod)) {
+                String prop = entry.getKey();
+                JsonNode modInfos = entry.getValue();
+                if ("*".equals(prop)) {
+                    doMod(originKey, target, copyFrom, modInfos, COPY_ENTRY_PROPS);
+                } else if ("_".equals(prop)) {
+                    doMod(originKey, target, copyFrom, modInfos, null);
+                } else {
+                    doMod(originKey, target, copyFrom, modInfos, List.of(prop));
+                }
+            }
+        }
+
+        // indicate that this is a copy, and remove copy metadata (avoid revisit)
+        target.put("_isCopy", true);
+        target.remove("_rawName");
+        MetaFields._copiedFrom.setIn(target, String.format("%s (%s)",
+                SourceField.name.getTextOrEmpty(copyFrom),
+                SourceField.source.getTextOrEmpty(copyFrom)));
+        MetaFields._copy.removeFrom(target);
+        return target;
+    }
+
+    protected abstract JsonNode resolveTemplateVariable(
+        TemplateVariable variableMode, String originKey, JsonNode value, JsonNode target, String... pieces);
+
+    // DataUtil.generic.variableResolver
+    /**
+     * @param value JsonNode to be checked for values to replace
+     * @param target JsonNode with attributes that can be used to resolve templates
+     */
+    private JsonNode resolveDynamicText(String originKey, JsonNode value, JsonNode target) {
+        if (value == null || !(value.isArray() || value.isObject() || value.isTextual())) {
+            return value;
+        }
+        if (value.isArray()) {
+            for (int i = 0; i < value.size(); i++) {
+                ((ArrayNode) value).set(i, resolveDynamicText(originKey, value.get(i), target));
+            }
+            return value;
+        }
+        if (value.isObject()) {
+            for (Entry<String, JsonNode> e : iterableFields(value)) {
+                e.setValue(resolveDynamicText(originKey, e.getValue(), target));
+            }
+            return value;
+        }
+        Matcher matcher = variable_subst.matcher(value.toString());
+        if (matcher.find()) {
+            String[] pieces = matcher.group("variable").split("__");
+            return requireNonNullElse(
+                resolveTemplateVariable(TemplateVariable.valueFrom(pieces[0]), originKey, value, target, pieces),
+                value);
+        }
+        return value;
+    }
+
+    private JsonNode normalizeMods(JsonNode copyMeta) {
+        if (copyMeta == null || !copyMeta.isObject()) {
+            return copyMeta;
+        }
+        for (String name : iterableFieldNames(copyMeta)) {
+            JsonNode mod = copyMeta.get(name);
+            if (!mod.isArray()) {
+                ((ObjectNode) copyMeta).set(name, mapper().createArrayNode().add(mod));
+            }
+        }
+        return copyMeta;
+    }
+
+    private void doMod(String originKey, ObjectNode target, JsonNode copyFrom, JsonNode modInfos, List<String> props) {
+        if (props == null || props.isEmpty()) { // '_' case
+            doModProp(originKey, modInfos, copyFrom, null, target);
+        } else {
+            for (String prop : props) {
+                doModProp(originKey, modInfos, copyFrom, prop, target);
+            }
+        }
+    }
+
+    /**
+     * Handle specific modifier properties before the common ones are handled by
+     * {@link #doModProp(String, JsonNode, JsonNode, String, ObjectNode)}.
+     *
+     * @param mode The specific modifier to handle
+     * @param originKey The key used to retrieve the original node
+     * @param modInfo Holds the info about the modification
+     * @param copyFrom The node to copy data from
+     * @param target The node to modify
+     * @return True if the mod was fully handled by this method, false if we need to fall back to the common handlers.
+     */
+    protected abstract boolean doModProp(
+        ModFieldMode mode, String originKey, JsonNode modInfo, JsonNode copyFrom, ObjectNode target);
+
+    void doModProp(String originKey, JsonNode modInfos, JsonNode copyFrom, String prop, ObjectNode target) {
+        for (JsonNode modInfo : iterableElements(modInfos)) {
+            if (modInfo.isTextual()) {
+                if ("remove".equals(modInfo.asText()) && prop != null) {
+                    target.remove(prop);
+                } else {
+                    tui().errorf("Error(%s): Unknown text modification mode for %s: %s", originKey, prop, modInfo);
+                }
+            } else {
+                ModFieldMode mode = ModFieldMode.valueFrom(modInfo, MetaFields.mode);
+                if (doModProp(mode, originKey, modInfo, copyFrom, target)) {
+                    return;
+                }
+                // Handle common mod props not handled by the specific implementation
+                switch (mode) {
+                    // Strings & text
+                    case appendStr -> doAppendText(originKey, modInfo, copyFrom, prop, target);
+                    case replaceName -> mode.notSupported(tui(), originKey, modInfo);
+                    case replaceTxt -> doReplaceText(originKey, modInfo, copyFrom, prop, target);
+                    // Arrays
+                    case prependArr, appendArr, replaceArr, replaceOrAppendArr, appendIfNotExistsArr, insertArr, removeArr ->
+                        doModArray(
+                                originKey, mode, modInfo, prop, target);
+                    // Properties
+                    case setProp -> doSetProp(originKey, modInfo, prop, target);
+                    // Bestiary
+                    case addSaves, addAllSaves, addAllSkills -> mode.notSupported(tui(), originKey, modInfo);
+                    // MATH
+                    case calculateProp -> mode.notSupported(tui(), originKey, modInfo);
+                    case scalarAddProp -> doScalarAddProp(originKey, modInfo, prop, target);
+                    case scalarMultProp -> doScalarMultProp(originKey, modInfo, prop, target);
+                    case scalarAddDc -> doScalarAddDc(originKey, modInfo, prop, target);
+                    case scalarAddHit -> doScalarAddHit(originKey, modInfo, prop, target);
+                    case maxSize -> doMaxSize(originKey, modInfo, target); // no prop
+                    default -> tui().errorf("Error (%s): Unknown modification mode: %s", originKey, modInfo);
+                }
+            }
+        }
+    }
+
+    void doAppendText(String originKey, JsonNode modInfo, JsonNode copyFrom, String prop, ObjectNode target) {
+        if (target.has(prop)) {
+            String joiner = MetaFields.joiner.getTextOrEmpty(modInfo);
+            target.put(prop, (target.has(prop) ? target.get(prop).asText() : "") + joiner
+                    + MetaFields.str.getTextOrEmpty(modInfo));
+        } else {
+            target.put(prop, MetaFields.str.getTextOrEmpty(modInfo));
+        }
+    }
+
+    void doReplaceText(String originKey, JsonNode modInfo, JsonNode copyFrom, String prop, ObjectNode target) {
+        if (!target.has(prop)) {
+            return;
+        }
+        if (!target.get(prop).isArray()) {
+            tui().warnf("replaceTxt for %s with a property %s that is not an array %s: %s", originKey, prop, modInfo,
+                    target.get(prop));
+            return;
+        }
+
+        String replace = MetaFields.replace.getTextOrEmpty(modInfo);
+        String with = MetaFields.with.getTextOrEmpty(modInfo);
+        JsonNode flags = MetaFields.flags.getFrom(modInfo);
+
+        final Pattern pattern;
+        if (flags != null) {
+            int pFlags = 0;
+            if (flags.asText().contains("i")) {
+                pFlags |= Pattern.CASE_INSENSITIVE;
+            }
+            pattern = Pattern.compile("\\b" + replace, pFlags);
+        } else {
+            pattern = Pattern.compile("\\b" + replace);
+        }
+
+        final boolean findPlainText;
+        final List<String> propNames;
+        JsonNode props = MetaFields.props.getFrom(modInfo);
+        if (props == null) {
+            findPlainText = true;
+            propNames = List.of("entries", "headerEntries", "footerEntries");
+        } else if (props.isEmpty()) {
+            tui().warnf("replaceText with empty props in %s: %s", originKey, modInfo);
+            return;
+        } else {
+            propNames = new ArrayList<>();
+            props.forEach(x -> propNames.add(x.isNull() ? "null" : x.asText()));
+            findPlainText = propNames.remove("null");
+        }
+
+        ArrayNode tgtArray = target.withArray(prop);
+        for (int i = 0; i < tgtArray.size(); i++) {
+            JsonNode it = tgtArray.get(i);
+            if (it.isTextual() && findPlainText) {
+                tgtArray.set(i, copyReplaceText(it, pattern, with));
+            } else if (it.isObject()) {
+                for (String k : propNames) {
+                    if (it.has(k)) {
+                        ((ObjectNode) it).set(k, copyReplaceText(it.get(k), pattern, with));
+                    }
+                }
+            }
+        }
+    }
+
+    private JsonNode copyReplaceText(JsonNode sourceNode, Pattern replace, String with) {
+        String modified = replace.matcher(sourceNode.toString()).replaceAll(with);
+        return createNode(modified);
+    }
+
+    private void doSetProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
+        List<String> propPath = List.of(MetaFields.prop.getTextOrEmpty(modInfo).split("\\."));
+        if (!"*".equals(prop)) {
+            propPath = new ArrayList<>(propPath);
+            propPath.add(0, prop);
+        }
+        String last = propPath.remove(propPath.size() - 1);
+
+        ObjectNode targetRw = ((ObjectNode) target).withObject("/" + String.join("/", propPath));
+        targetRw.set(last, copyNode(MetaFields.value.getFrom(modInfo)));
+    }
+
+    private void doScalarAddHit(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
+        final Pattern hitPattern = Pattern.compile("\\{@hit ([-+]?\\d+)}");
+        if (!target.has(prop)) {
+            return;
+        }
+
+        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
+        String fullNode = hitPattern.matcher(target.get(prop).toString())
+                .replaceAll((match) -> "{@hit " + (Integer.parseInt(match.group(1)) + scalar) + "}");
+        target.set(prop, createNode(fullNode));
+    }
+
+    private void doScalarAddDc(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
+        final Pattern dcPattern = Pattern.compile("\\{@dc (\\d+)(?:\\|[^}]+)?}");
+        if (!target.has(prop)) {
+            return;
+        }
+        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
+        String fullNode = dcPattern.matcher(target.get(prop).toString())
+                .replaceAll((match) -> "{@dc " + (Integer.parseInt(match.group(1)) + scalar) + "}");
+        target.set(prop, createNode(fullNode));
+    }
+
+    private void doScalarAddProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
+        if (!target.has(prop)) {
+            return;
+        }
+        ObjectNode propRw = (ObjectNode) target.get(prop);
+        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
+        Consumer<String> scalarAdd = (k) -> {
+            JsonNode node = propRw.get(k);
+            boolean isString = node.isTextual();
+            int value = isString
+                    ? Integer.parseInt(node.asText())
+                    : node.asInt();
+            value += scalar;
+            propRw.replace(k, isString
+                    ? new TextNode("+%d".formatted(value))
+                    : new IntNode(value));
+        };
+
+        String modProp = MetaFields.prop.getTextOrNull(modInfo);
+        if ("*".equals(modProp)) {
+            for (String fieldName : iterableFieldNames(propRw)) {
+                scalarAdd.accept(fieldName);
+            }
+        } else {
+            scalarAdd.accept(modProp);
+        }
+    }
+
+    private void doScalarMultProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
+        if (!target.has(prop)) {
+            return;
+        }
+        ObjectNode propRw = (ObjectNode) target.get(prop);
+        double scalar = MetaFields.scalar.getFrom(modInfo).asDouble();
+        boolean floor = MetaFields.floor.booleanOrDefault(modInfo, false);
+        Consumer<String> scalarMult = (k) -> {
+            JsonNode node = propRw.get(k);
+            boolean isString = node.isTextual();
+            double value = isString
+                    ? Double.parseDouble(node.asText())
+                    : node.asDouble();
+            value *= scalar;
+            if (floor) {
+                value = Math.floor(value);
+            }
+            propRw.replace(k, isString
+                    ? new TextNode("+%f".formatted(value))
+                    : new DoubleNode(value));
+        };
+
+        String modProp = MetaFields.prop.getTextOrNull(modInfo);
+        if ("*".equals(modProp)) {
+            for (String fieldName : iterableFieldNames(propRw)) {
+                scalarMult.accept(fieldName);
+            }
+        } else {
+            scalarMult.accept(modProp);
+        }
+    }
+
+    private void doMaxSize(String originKey, JsonNode modInfo, ObjectNode target) {
+        final String SIZES = "FDTSMLHGCV";
+        if (!MetaFields.size.existsIn(target)) {
+            tui().errorf("Error (%s): enforcing maxSize on an object that does not define size; %s", originKey, target);
+            return;
+        }
+
+        String maxValue = MetaFields.max.getTextOrEmpty(modInfo);
+        int maxIdx = SIZES.indexOf(maxValue);
+        if (maxValue.isBlank() || maxIdx < 0) {
+            tui().errorf("Error (%s): Invalid maxSize value %s", originKey, maxValue.isBlank() ? "(missing)" : maxValue);
+            return;
+        }
+
+        ArrayNode size = MetaFields.size.ensureArrayIn(target);
+        List<JsonNode> collect = streamOf(size)
+                .filter(x -> SIZES.indexOf(x.asText()) <= maxIdx)
+                .collect(Collectors.toList());
+
+        if (size.size() != collect.size()) {
+            size.removeAll();
+            if (collect.isEmpty()) {
+                size.add(new TextNode(maxValue));
+            } else {
+                size.addAll(collect);
+            }
+        }
+    }
+
+    void doModArray(String originKey, ModFieldMode mode, JsonNode modInfo, String prop, ObjectNode target) {
+        JsonNode items = ensureArray(MetaFields.items.getFrom(modInfo));
+        switch (mode) {
+            case prependArr -> {
+                ArrayNode tgtArray = target.withArray(prop);
+                insertIntoArray(tgtArray, 0, items);
+            }
+            case appendArr -> {
+                ArrayNode tgtArray = target.withArray(prop);
+                appendToArray(tgtArray, items);
+            }
+            case appendIfNotExistsArr -> {
+                ArrayNode tgtArray = target.withArray(prop);
+                appendIfNotExistsArr(tgtArray, items);
+            }
+            case insertArr -> {
+                if (!target.has(prop)) {
+                    tui().errorf("Error (%s): Unable to insert into array; %s is not present: %s", originKey, prop, target);
+                    return;
+                }
+                ArrayNode tgtArray = target.withArray(prop);
+                int index = MetaFields.index.intOrDefault(modInfo, -1);
+                if (index < 0) {
+                    index = tgtArray.size();
+                }
+                insertIntoArray(tgtArray, index, items);
+            }
+            case removeArr -> {
+                if (!target.has(prop)) {
+                    tui().errorf("Error (%s): Unable to remove from array; %s is not present: %s", originKey, prop, target);
+                    return;
+                }
+                ArrayNode tgtArray = target.withArray(prop);
+                removeFromArray(originKey, modInfo, prop, tgtArray);
+            }
+            case replaceArr -> {
+                if (!target.has(prop)) {
+                    tui().errorf("Error (%s): Unable to replace array; %s is not present: %s", originKey, prop, target);
+                    return;
+                }
+                ArrayNode tgtArray = target.withArray(prop);
+                replaceArray(originKey, modInfo, tgtArray, items);
+            }
+            case replaceOrAppendArr -> {
+                ArrayNode tgtArray = target.withArray(prop);
+                boolean didReplace = false;
+                if (tgtArray.size() > 0) {
+                    didReplace = replaceArray(originKey, modInfo, tgtArray, items);
+                }
+                if (!didReplace) {
+                    appendToArray(tgtArray, items);
+                }
+            }
+            default -> tui().errorf("Error (%s): Unknown modification mode for property %s: %s", originKey, prop, modInfo);
+        }
+    }
+
+    protected void appendToArray(ArrayNode tgtArray, JsonNode items) {
+        if (items == null) {
+            return;
+        }
+        if (items.isArray()) {
+            tgtArray.addAll((ArrayNode) items);
+        } else {
+            tgtArray.add(items);
+        }
+    }
+
+    protected void insertIntoArray(ArrayNode tgtArray, int index, JsonNode items) {
+        if (items == null) {
+            return;
+        }
+        if (items.isArray()) {
+            // iterate backwards so that items end up in the right order @ desired index
+            for (int i = items.size() - 1; i >= 0; i--) {
+                tgtArray.insert(index, items.get(i));
+            }
+        } else {
+            tgtArray.insert(index, items);
+        }
+    }
+
+    public void appendIfNotExistsArr(ArrayNode tgtArray, JsonNode items) {
+        if (items == null) {
+            return;
+        }
+        if (tgtArray.isEmpty()) {
+            appendToArray(tgtArray, items);
+        } else {
+            // Remove inbound items that already exist in the target array
+            // Use anyMatch to stop filtering ASAP
+            List<JsonNode> filtered = streamOf(items)
+                    .filter(it -> streamOf(tgtArray).noneMatch(it::equals))
+                    .collect(Collectors.toList());
+            tgtArray.addAll(filtered);
+        }
+    }
+
+    protected void removeFromArray(String originKey, JsonNode modInfo, String prop, ArrayNode tgtArray) {
+        JsonNode names = ensureArray(MetaFields.names.getFrom(modInfo));
+        JsonNode items = ensureArray(MetaFields.items.getFrom(modInfo));
+        if (names != null) {
+            for (JsonNode name : iterableElements(names)) {
+                int index = findIndexByName(originKey, tgtArray, name.asText());
+                if (index >= 0) {
+                    tgtArray.remove(index);
+                } else if (!MetaFields.force.booleanOrDefault(modInfo, false)) {
+                    tui().errorf("Error (%s / %s): Unable to remove %s; %s", originKey, prop, name.asText(), modInfo);
+                }
+            }
+        } else if (items != null) {
+            removeFromArr(tgtArray, items);
+        } else {
+            tui().errorf("Error (%s / %s): One of names or items must be provided to remove elements from array; %s", originKey,
+                    prop, modInfo);
+        }
+    }
+
+    public void removeFromArr(ArrayNode tgtArray, JsonNode items) {
+        for (JsonNode itemToRemove : iterableElements(items)) {
+            int index = findIndex(tgtArray, itemToRemove);
+            if (index >= 0) {
+                tgtArray.remove(index);
+            }
+        }
+    }
+
+    protected boolean replaceArray(String originKey, JsonNode modInfo, ArrayNode tgtArray, JsonNode items) {
+        if (items == null || !items.isArray()) {
+            return false;
+        }
+        JsonNode replace = MetaFields.replace.getFrom(modInfo);
+
+        final int index;
+        if (replace.isTextual()) {
+            index = findIndexByName(originKey, tgtArray, replace.asText());
+        } else if (replace.isObject() && MetaFields.index.existsIn(replace)) {
+            index = MetaFields.index.intOrDefault(replace, 0);
+        } else if (replace.isObject() && MetaFields.regex.existsIn(replace)) {
+            Pattern pattern = Pattern.compile("\\b" + MetaFields.regex.getTextOrEmpty(replace));
+            index = matchFirstIndexByName(originKey, tgtArray, pattern);
+        } else {
+            tui().errorf("Error (%s): Unknown replace; %s", originKey, modInfo);
+            return false;
+        }
+
+        if (index >= 0) {
+            tgtArray.remove(index);
+            insertIntoArray(tgtArray, index, items);
+            return true;
+        }
+        return false;
+    }
+
+    protected int matchFirstIndexByName(String originKey, ArrayNode haystack, Pattern needle) {
+        for (int i = 0; i < haystack.size(); i++) {
+            final String toMatch;
+            if (haystack.get(i).isObject()) {
+                toMatch = SourceField.name.getTextOrEmpty(haystack.get(i));
+            } else if (haystack.get(i).isTextual()) {
+                toMatch = haystack.asText();
+            } else {
+                continue;
+            }
+            if (!toMatch.isBlank() && needle.matcher(toMatch).find()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    protected int findIndexByName(String originKey, ArrayNode haystack, String needle) {
+        for (int i = 0; i < haystack.size(); i++) {
+            final String toMatch;
+            if (haystack.get(i).isObject()) {
+                toMatch = SourceField.name.getTextOrEmpty(haystack.get(i));
+            } else if (haystack.get(i).isTextual()) {
+                toMatch = haystack.get(i).asText();
+            } else {
+                continue;
+            }
+            if (needle.equals(toMatch)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    protected int findIndex(ArrayNode haystack, JsonNode needle) {
+        for (int i = 0; i < haystack.size(); i++) {
+            if (haystack.get(i).equals(needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public enum MetaFields implements JsonNodeReader {
+        _copy,
+        _copiedFrom, // mind
+        _mod,
+        _preserve,
+        _root,
+        _trait,
+        alias,
+        apply,
+        data,
+        dex,
+        dex_mod,
+        flags,
+        floor,
+        force,
+        index,
+        items,
+        joiner,
+        max,
+        mode,
+        names,
+        overwrite,
+        prof_bonus,
+        prop,
+        props,
+        range,
+        regex,
+        replace,
+        root,
+        scalar,
+        size,
+        skills,
+        str,
+        type,
+        value,
+        with,
+        ;
+    }
+
+    protected enum TemplateVariable implements JsonNodeReader.FieldValue {
+        name,
+        short_name,
+        title_short_name,
+        dc,
+        spell_dc,
+        to_hit,
+        damage_mod,
+        damage_avg;
+
+        static TemplateVariable valueFrom(String value) {
+            return Stream.of(TemplateVariable.values())
+                    .filter((t) -> t.matches(value))
+                    .findFirst().orElse(null);
+        }
+
+        @Override
+        public String value() {
+            return name();
+        }
+
+        public void notSupported(Tui tui, String originKey, JsonNode variableText) {
+            tui.errorf("Error (%s): Support for %s must be implemented. Raise an issue with this message. Text: %s",
+                    originKey, this.value(), variableText);
+        }
+    }
+
+    protected enum ModFieldMode implements JsonNodeReader.FieldValue {
+        appendStr,
+        replaceName,
+        replaceTxt,
+
+        prependArr,
+        appendArr,
+        replaceArr,
+        replaceOrAppendArr,
+        appendIfNotExistsArr,
+        insertArr,
+        removeArr,
+
+        calculateProp,
+        scalarAddProp,
+        scalarMultProp,
+        setProp,
+
+        addSenses,
+        addSaves,
+        addSkills,
+        addAllSaves,
+        addAllSkills,
+
+        addSpells,
+        removeSpells,
+        replaceSpells,
+
+        maxSize,
+        scalarMultXp,
+        scalarAddHit,
+        scalarAddDc;
+
+        static ModFieldMode valueFrom(JsonNode source, JsonNodeReader field) {
+            String textOrNull = field.getTextOrNull(source);
+            if (textOrNull == null) {
+                return null;
+            }
+            return Stream.of(ModFieldMode.values())
+                    .filter((t) -> t.matches(textOrNull))
+                    .findFirst().orElse(null);
+        }
+
+        @Override
+        public String value() {
+            return name();
+        }
+
+        public void notSupported(Tui tui, String originKey, JsonNode modInfo) {
+            tui.errorf("Error (%s): %s must be implemented. Raise an issue with this message. modInfo: %s",
+                    originKey, this.value(), modInfo);
+        }
+    }
+}

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteItem.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteItem.java
@@ -344,7 +344,7 @@ public class Json2QuteItem extends Json2QuteCommon {
 
     /** Update / replace item with variants (where appropriate) */
     public static List<Tuple> findGroupVariant(Tools5eIndex index, Tools5eIndexType type,
-            String key, JsonNode itemGroup, JsonSourceCopier copier) {
+            String key, JsonNode itemGroup, Tools5eJsonSourceCopier copier) {
 
         // Update type & key for the new item
         final JsonNode item = copier.copyNode(itemGroup);

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
@@ -549,7 +549,7 @@ public interface JsonSource extends JsonTextReplacement {
         TtrpgValue.indexInputType.setIn(data, type.name());
 
         // TODO: Remove me.
-        JsonNode copy = JsonSourceCopier.MetaFields._copy.getFrom(data);
+        JsonNode copy = Tools5eJsonSourceCopier.MetaFields._copy.getFrom(data);
         if (copy != null) {
             String copyName = SourceField.name.getTextOrEmpty(copy).strip();
             String copySource = SourceField.source.getTextOrEmpty(copy).strip();
@@ -557,7 +557,7 @@ public interface JsonSource extends JsonTextReplacement {
                 embedReference(text, data, type, heading); // embed note that will be present in the final output
                 return;
             }
-            JsonSourceCopier copier = new JsonSourceCopier(index());
+            Tools5eJsonSourceCopier copier = new Tools5eJsonSourceCopier(index());
             data = copier.handleCopy(type, data);
             existingNode = null; // this is a modified node, ignore existing.
         } else if (equivalentNode(data, existingNode) && index().isIncluded(finalKey)) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
@@ -26,7 +26,6 @@ import dev.ebullient.convert.tools.JsonTextConverter;
 import dev.ebullient.convert.tools.ParseState;
 import dev.ebullient.convert.tools.ToolsIndex.TtrpgValue;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteClass.ClassFeature;
-import dev.ebullient.convert.tools.dnd5e.JsonSourceCopier.MetaFields;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -550,7 +549,7 @@ public interface JsonSource extends JsonTextReplacement {
         TtrpgValue.indexInputType.setIn(data, type.name());
 
         // TODO: Remove me.
-        JsonNode copy = MetaFields._copy.getFrom(data);
+        JsonNode copy = JsonSourceCopier.MetaFields._copy.getFrom(data);
         if (copy != null) {
             String copyName = SourceField.name.getTextOrEmpty(copy).strip();
             String copySource = SourceField.source.getTextOrEmpty(copy).strip();

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSourceCopier.java
@@ -2,7 +2,6 @@ package dev.ebullient.convert.tools.dnd5e;
 
 import static dev.ebullient.convert.StringUtil.toTitleCase;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -10,64 +9,37 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Consumer;
 import java.util.function.ToDoubleFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.tools.JsonCopyException;
-import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteMonster.MonsterFields;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteRace.RaceFields;
 
-public class JsonSourceCopier implements JsonSource {
-    static final List<String> GENERIC_WALKER_ENTRIES_KEY_BLOCKLIST = List.of("caption", "type", "colLabels", "colLabelGroups",
-            "name", "colStyles", "style", "shortName", "subclassShortName", "id", "path");
-
-    static final List<String> _MERGE_REQUIRES_PRESERVE_BASE = List.of(
-            "_versions",
-            "basicRules",
-            "hasFluff",
-            "hasFluffImages",
-            "hasToken",
-            "indexInputType", // mine: do I have the usage right?
-            "indexKey", // mine: do I have the usage right?
-            "otherSources",
-            "page",
-            "reprintedAs",
-            "srd");
+public class JsonSourceCopier extends dev.ebullient.convert.tools.JsonSourceCopier<Tools5eIndexType> implements JsonSource {
     static final Map<Tools5eIndexType, List<String>> _MERGE_REQUIRES_PRESERVE = Map.of(
             Tools5eIndexType.monster, List.of("legendaryGroup", "environment", "soundClip",
                     "altArt", "variant", "dragonCastingColor", "familiar"),
             Tools5eIndexType.item, List.of("lootTables", "tier"),
             Tools5eIndexType.itemGroup, List.of("lootTables", "tier"));
-    static final List<String> COPY_ENTRY_PROPS = List.of(
-            "action", "bonus", "reaction", "trait", "legendary", "mythic", "variant", "spellcasting",
-            "actionHeader", "bonusHeader", "reactionHeader", "legendaryHeader", "mythicHeader");
     static final List<String> LEARNED_SPELL_TYPE = List.of("constant", "will", "ritual");
     static final List<String> SPELL_CAST_FREQUENCY = List.of("recharge", "charges", "rest", "daily", "weekly", "yearly");
 
     static final Pattern variable_subst = Pattern.compile("<\\$(?<variable>[^$]+)\\$>");
     static final Pattern dmg_avg_subst = Pattern.compile("([\\d.,]+)([+*-])([^$]+)");
 
-    static boolean mergePreserveKey(Tools5eIndexType type, String key) {
+    @Override
+    protected boolean mergePreserveKey(Tools5eIndexType type, String key) {
         List<String> preserveType = _MERGE_REQUIRES_PRESERVE.getOrDefault(type, List.of());
-        return _MERGE_REQUIRES_PRESERVE_BASE.contains(key) || preserveType.contains(key);
-    }
-
-    static boolean metaPreserveKey(JsonNode _preserve, String key) {
-        return _preserve != null && (_preserve.has("*") || _preserve.has(key));
+        return super.mergePreserveKey(type, key) || preserveType.contains(key);
     }
 
     final Tools5eIndex index;
@@ -84,31 +56,6 @@ public class JsonSourceCopier implements JsonSource {
     @Override
     public Tools5eSources getSources() {
         throw new IllegalStateException("Should not call getSources while copying source");
-    }
-
-    JsonNode handleCopy(Tools5eIndexType type, JsonNode copyTo) {
-        String copyToKey = type.createKey(copyTo);
-        JsonNode _copy = MetaFields._copy.getFrom(copyTo);
-        if (_copy != null) {
-            String copyFromKey = type.createKey(_copy);
-            JsonNode copyFrom = index().getOriginNoFallback(copyFromKey);
-            if (copyToKey.equals(copyFromKey)) {
-                tui().errorf("Error (%s): Self-referencing copy. This is a data entry error. %s", copyToKey, _copy);
-                return copyTo;
-            }
-            if (copyFrom == null) {
-                tui().errorf("Error (%s): Unable to find source for %s", copyToKey, copyFromKey);
-                return copyTo;
-            }
-            // is the copy a copy?
-            copyFrom = handleCopy(type, copyFrom);
-            try {
-                copyTo = mergeNodes(type, copyToKey, copyFrom, copyTo);
-            } catch (JsonCopyException | StackOverflowError | UnsupportedOperationException e) {
-                tui().errorf(e, "Error (%s): Unable to merge nodes. CopyTo: %s, CopyFrom: %s", copyToKey, copyTo, copyFrom);
-            }
-        }
-        return copyTo;
     }
 
     // render.js: _getMergedSubrace
@@ -218,331 +165,81 @@ public class JsonSourceCopier implements JsonSource {
         return subraceOut;
     }
 
-    // 	utils.js: static getCopy (impl, copyFrom, copyTo, templateData,...) {
-    JsonNode mergeNodes(Tools5eIndexType type, String originKey, JsonNode copyFrom, JsonNode copyTo) {
-        // edit in place: if you don't, lower-level copies will keep being revisted.
-        ObjectNode target = (ObjectNode) copyTo;
-
-        JsonNode _copy = MetaFields._copy.getFrom(copyTo);
-        JsonNode _mod = _copy == null ? null : normalizeMods(MetaFields._mod.getFrom(_copy));
-        JsonNode _trait = _copy == null ? null : MetaFields._trait.getFrom(_copy);
-
-        JsonNode templateApplyRoot = null;
-
-        if (_trait != null) {
-            // fetch and apply external template mods
-            String templateKey = Tools5eIndexType.monsterTemplate.createKey(_trait);
-            JsonNode template = index.getOriginNoFallback(templateKey);
-            if (template == null) {
-                tui().warn("Unable to find trait for " + templateKey);
-            } else {
-                template = copyNode(template); // copy fast
-
-                JsonNode apply = MetaFields.apply.getFrom(template);
-                templateApplyRoot = MetaFields._root.getFrom(apply);
-
-                JsonNode templateMods = normalizeMods(MetaFields._mod.getFrom(apply));
-                if (templateMods != null) {
-                    if (_mod == null) {
-                        _mod = templateMods;
-                    } else {
-                        ObjectNode _modRw = (ObjectNode) _mod;
-                        for (Entry<String, JsonNode> e : iterableFields(templateMods)) {
-                            if (_modRw.has(e.getKey())) {
-                                appendToArray(_modRw.withArray(e.getKey()), e.getValue());
-                            } else {
-                                _modRw.set(e.getKey(), e.getValue());
-                            }
-                        }
-                    }
-                }
-            }
-            MetaFields._trait.removeFrom(_copy);
-        }
-
-        JsonNode _preserve = _copy == null
-                ? mapper().createObjectNode()
-                : MetaFields._preserve.getFrom(_copy);
-
-        // Copy required values from...
-        for (Entry<String, JsonNode> from : iterableFields(copyFrom)) {
-            String k = from.getKey();
-            JsonNode copyToField = copyTo.get(k);
-            if (copyToField != null && copyToField.isNull()) {
-                // copyToField exists as `null`. Remove the field.
-                target.remove(k);
-                continue;
-            }
-            if (copyToField == null) {
-                // not already present in copyTo -- should we copyFrom?
-                // Do merge rules indicate the value should be preserved
-                if (mergePreserveKey(type, k)) {
-                    // Does metadata indicate that it should be copied?
-                    if (metaPreserveKey(_preserve, k)) {
-                        target.set(k, copyNode(from.getValue()));
-                    }
-                } else {
-                    // in general, yes.
-                    target.set(k, copyNode(from.getValue()));
-                }
-            }
-        }
-
-        // Apply template _root properties
-        List<String> copyToRootProps = streamOfFieldNames(copyTo).toList();
-        if (templateApplyRoot != null) {
-            for (Entry<String, JsonNode> from : iterableFields(templateApplyRoot)) {
-                String k = from.getKey();
-                if (!copyToRootProps.contains(k)) {
-                    continue; // avoid overwriting any real properties with templates
-                }
-                target.set(k, copyNode(from.getValue()));
-            }
-        }
-
-        // Apply mods
-        if (_mod != null) {
-            for (Entry<String, JsonNode> entry : iterableFields(_mod)) {
-                // use the copyTo value as the attribute source for resolving dynamic text
-                entry.setValue(resolveDynamicText(originKey, entry.getValue(), copyTo));
-            }
-
-            for (Entry<String, JsonNode> entry : iterableFields(_mod)) {
-                String prop = entry.getKey();
-                JsonNode modInfos = entry.getValue();
-                if ("*".equals(prop)) {
-                    doMod(originKey, target, copyFrom, modInfos, COPY_ENTRY_PROPS);
-                } else if ("_".equals(prop)) {
-                    doMod(originKey, target, copyFrom, modInfos, null);
-                } else {
-                    doMod(originKey, target, copyFrom, modInfos, List.of(prop));
-                }
-            }
-        }
-
-        // indicate that this is a copy, and remove copy metadata (avoid revisit)
-        target.put("_isCopy", true);
-        target.remove("_rawName");
-        MetaFields._copiedFrom.setIn(target, String.format("%s (%s)",
-                SourceField.name.getTextOrEmpty(copyFrom),
-                SourceField.source.getTextOrEmpty(copyFrom)));
-        MetaFields._copy.removeFrom(target);
-        return target;
+    @Override
+    protected JsonNode getOriginNode(String key) {
+        return index.getOriginNoFallback(key);
     }
 
-    // DataUtil.generic.variableResolver
-    /**
-     * @param value JsonNode to be checked for values to replace
-     * @param copyTo JsonNode with attributes that can be used to resolve templates
-     */
-    private JsonNode resolveDynamicText(String originKey, JsonNode value, JsonNode target) {
-        if (value == null || !(value.isArray() || value.isObject() || value.isTextual())) {
-            return value;
-        }
-        if (value.isArray()) {
-            for (int i = 0; i < value.size(); i++) {
-                ((ArrayNode) value).set(i, resolveDynamicText(originKey, value.get(i), target));
-            }
-            return value;
-        }
-        if (value.isObject()) {
-            for (Entry<String, JsonNode> e : iterableFields(value)) {
-                e.setValue(resolveDynamicText(originKey, e.getValue(), target));
-            }
-            return value;
-        }
-        Matcher matcher = variable_subst.matcher(value.toString());
-        while (matcher.find()) {
-            String[] pieces = matcher.group("variable").split("__");
-            TemplateVariable variableMode = TemplateVariable.valueFrom(pieces[0]);
-            return switch (variableMode) {
-                case name -> new TextNode(SourceField.name.getTextOrEmpty(target));
-                case short_name -> new TextNode(getShortName(target, false));
-                case title_short_name -> new TextNode(getShortName(target, true));
-                case dc, spell_dc -> {
-                    if (pieces.length < 2 || !target.has(pieces[1])) {
-                        tui().errorf("Error (%s): Missing detail for %s", originKey, value);
-                        yield value;
-                    }
-                    int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
-                    int pb = crToPb(MonsterFields.cr.getFrom(target));
-                    yield new TextNode("" + (8 + pb + mod));
-                }
-                case to_hit -> {
-                    if (pieces.length < 2 || !target.has(pieces[1])) {
-                        tui().errorf("Error (%s): Missing detail for %s", originKey, value);
-                        yield value;
-                    }
-                    int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
-                    int pb = crToPb(MonsterFields.cr.getFrom(target));
-                    yield new TextNode(asModifier(pb + mod));
-                }
-                case damage_mod -> {
-                    if (pieces.length < 2 || !target.has(pieces[1])) {
-                        tui().errorf("Error (%s): Missing detail for %s", originKey, value);
-                        yield value;
-                    }
-                    int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
-                    yield new TextNode(mod == 0 ? "" : asModifier(mod));
-                }
-                case damage_avg -> {
-                    Matcher m = dmg_avg_subst.matcher(pieces[1]);
-                    if (m.matches()) {
-                        String amount = m.group(1);
-                        String op = m.group(2);
-                        int mod = getAbilityModNumber(target.get(m.group(3)).asInt());
-                        if ("+".equals(op)) {
-                            double total = Double.parseDouble(amount) + mod;
-                            yield new TextNode("" + Math.floor(total));
-                        }
-                    }
-                    tui().errorf("Error (%s): Unrecognized damage average template %s", originKey, value);
-                    yield value;
-                }
-                default -> {
-                    variableMode.notSupported(tui(), originKey, value);
-                    yield value;
-                }
-            };
-        }
-        return value;
+    @Override
+    protected String getExternalTemplateKey(JsonNode trait) {
+        return Tools5eIndexType.monsterTemplate.createKey(trait);
     }
 
-    private JsonNode normalizeMods(JsonNode copyMeta) {
-        if (copyMeta == null || !copyMeta.isObject()) {
-            return copyMeta;
-        }
-        for (String name : iterableFieldNames(copyMeta)) {
-            JsonNode mod = copyMeta.get(name);
-            if (!mod.isArray()) {
-                ((ObjectNode) copyMeta).set(name, mapper().createArrayNode().add(mod));
-            }
-        }
-        return copyMeta;
-    }
-
-    private void doMod(String originKey, ObjectNode target, JsonNode copyFrom, JsonNode modInfos, List<String> props) {
-        if (props == null || props.isEmpty()) { // '_' case
-            doModProp(originKey, modInfos, copyFrom, null, target);
-        } else {
-            for (String prop : props) {
-                doModProp(originKey, modInfos, copyFrom, prop, target);
-            }
-        }
-    }
-
-    void doModProp(String originKey, JsonNode modInfos, JsonNode copyFrom, String prop, ObjectNode target) {
-        for (JsonNode modInfo : iterableElements(modInfos)) {
-            if (modInfo.isTextual()) {
-                if ("remove".equals(modInfo.asText()) && prop != null) {
-                    target.remove(prop);
-                } else {
-                    tui().errorf("Error(%s): Unknown text modification mode for %s: %s", originKey, prop, modInfo);
+    @Override
+    protected JsonNode resolveTemplateVariable(
+            TemplateVariable variableMode, String originKey, JsonNode value, JsonNode target, String... pieces) {
+        return switch (variableMode) {
+            case name -> new TextNode(SourceField.name.getTextOrEmpty(target));
+            case short_name -> new TextNode(getShortName(target, false));
+            case title_short_name -> new TextNode(getShortName(target, true));
+            case dc, spell_dc -> {
+                if (pieces.length < 2 || !target.has(pieces[1])) {
+                    tui().errorf("Error (%s): Missing detail for %s", originKey, value);
+                    yield null;
                 }
-            } else {
-                ModFieldMode mode = ModFieldMode.valueFrom(modInfo, MetaFields.mode);
-                switch (mode) {
-                    // Strings & text
-                    case appendStr -> doAppendText(originKey, modInfo, copyFrom, prop, target);
-                    case replaceName -> mode.notSupported(tui(), originKey, modInfo);
-                    case replaceTxt -> doReplaceText(originKey, modInfo, copyFrom, prop, target);
-                    // Arrays
-                    case prependArr, appendArr, replaceArr, replaceOrAppendArr, appendIfNotExistsArr, insertArr, removeArr ->
-                        doModArray(
-                                originKey, mode, modInfo, prop, target);
-                    // Properties
-                    case setProp -> doSetProp(originKey, modInfo, prop, target);
-                    // Bestiary
-                    case addSenses -> doAddSenses(originKey, modInfo, copyFrom, target); // no prop
-                    case addSaves -> mode.notSupported(tui(), originKey, modInfo);
-                    case addSkills -> doAddSkills(originKey, modInfo, target); // no prop
-                    case addAllSaves -> mode.notSupported(tui(), originKey, modInfo);
-                    case addAllSkills -> mode.notSupported(tui(), originKey, modInfo);
-                    case addSpells -> doAddSpells(originKey, modInfo, copyFrom, target); // no prop
-                    case replaceSpells -> doReplaceSpells(originKey, modInfo, copyFrom, target); // no prop
-                    case removeSpells -> doRemoveSpells(originKey, modInfo, copyFrom, target); // no prop
-                    // MATH
-                    case calculateProp -> mode.notSupported(tui(), originKey, modInfo);
-                    case scalarAddProp -> doScalarAddProp(originKey, modInfo, prop, target);
-                    case scalarMultProp -> doScalarMultProp(originKey, modInfo, prop, target);
-                    case scalarMultXp -> doScalarMultXp(originKey, modInfo, target); // no prop
-                    case scalarAddDc -> doScalarAddDc(originKey, modInfo, prop, target);
-                    case scalarAddHit -> doScalarAddHit(originKey, modInfo, prop, target);
-                    case maxSize -> doMaxSize(originKey, modInfo, target); // no prop
-                    default -> tui().errorf("Error (%s): Unknown modification mode: %s", originKey, modInfo);
+                int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
+                int pb = crToPb(MonsterFields.cr.getFrom(target));
+                yield new TextNode("" + (8 + pb + mod));
+            }
+            case to_hit -> {
+                if (pieces.length < 2 || !target.has(pieces[1])) {
+                    tui().errorf("Error (%s): Missing detail for %s", originKey, value);
+                    yield null;
                 }
+                int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
+                int pb = crToPb(MonsterFields.cr.getFrom(target));
+                yield new TextNode(asModifier(pb + mod));
             }
-        }
-    }
-
-    void doAppendText(String originKey, JsonNode modInfo, JsonNode copyFrom, String prop, ObjectNode target) {
-        if (target.has(prop)) {
-            String joiner = MetaFields.joiner.getTextOrEmpty(modInfo);
-            target.put(prop, getTextOrEmpty(target, prop) + joiner
-                    + MetaFields.str.getTextOrEmpty(modInfo));
-        } else {
-            target.put(prop, MetaFields.str.getTextOrEmpty(modInfo));
-        }
-    }
-
-    void doReplaceText(String originKey, JsonNode modInfo, JsonNode copyFrom, String prop, ObjectNode target) {
-        if (!target.has(prop)) {
-            return;
-        }
-        if (!target.get(prop).isArray()) {
-            tui().warnf("replaceTxt for %s with a property %s that is not an array %s: %s", originKey, prop, modInfo,
-                    target.get(prop));
-            return;
-        }
-
-        String replace = MetaFields.replace.getTextOrEmpty(modInfo);
-        String with = MetaFields.with.getTextOrEmpty(modInfo);
-        JsonNode flags = MetaFields.flags.getFrom(modInfo);
-
-        final Pattern pattern;
-        if (flags != null) {
-            int pFlags = 0;
-            if (flags.asText().contains("i")) {
-                pFlags |= Pattern.CASE_INSENSITIVE;
+            case damage_mod -> {
+                if (pieces.length < 2 || !target.has(pieces[1])) {
+                    tui().errorf("Error (%s): Missing detail for %s", originKey, value);
+                    yield null;
+                }
+                int mod = getAbilityModNumber(target.get(pieces[1]).asInt());
+                yield new TextNode(mod == 0 ? "" : asModifier(mod));
             }
-            pattern = Pattern.compile("\\b" + replace, pFlags);
-        } else {
-            pattern = Pattern.compile("\\b" + replace);
-        }
-
-        final boolean findPlainText;
-        final List<String> propNames;
-        JsonNode props = MetaFields.props.getFrom(modInfo);
-        if (props == null) {
-            findPlainText = true;
-            propNames = List.of("entries", "headerEntries", "footerEntries");
-        } else if (props.isEmpty()) {
-            tui().warnf("replaceText with empty props in %s: %s", originKey, modInfo);
-            return;
-        } else {
-            propNames = new ArrayList<>();
-            props.forEach(x -> propNames.add(x.isNull() ? "null" : x.asText()));
-            findPlainText = propNames.remove("null");
-        }
-
-        ArrayNode tgtArray = target.withArray(prop);
-        for (int i = 0; i < tgtArray.size(); i++) {
-            JsonNode it = tgtArray.get(i);
-            if (it.isTextual() && findPlainText) {
-                tgtArray.set(i, copyReplaceText(it, pattern, with));
-            } else if (it.isObject()) {
-                for (String k : propNames) {
-                    if (it.has(k)) {
-                        ((ObjectNode) it).set(k, copyReplaceText(it.get(k), pattern, with));
+            case damage_avg -> {
+                Matcher m = dmg_avg_subst.matcher(pieces[1]);
+                if (m.matches()) {
+                    String amount = m.group(1);
+                    String op = m.group(2);
+                    int mod = getAbilityModNumber(target.get(m.group(3)).asInt());
+                    if ("+".equals(op)) {
+                        double total = Double.parseDouble(amount) + mod;
+                        yield new TextNode("" + Math.floor(total));
                     }
                 }
+                tui().errorf("Error (%s): Unrecognized damage average template %s", originKey, value);
+                yield null;
             }
-        }
+        };
     }
 
-    private JsonNode copyReplaceText(JsonNode sourceNode, Pattern replace, String with) {
-        String modified = replace.matcher(sourceNode.toString()).replaceAll(with);
-        return createNode(modified);
+    @Override
+    protected boolean doModProp(
+            ModFieldMode mode, String originKey, JsonNode modInfo, JsonNode copyFrom, ObjectNode target) {
+        switch (mode) {
+            case addSenses -> doAddSenses(originKey, modInfo, copyFrom, target);
+            case addSkills -> doAddSkills(originKey, modInfo, target);
+            case addSpells -> doAddSpells(originKey, modInfo, copyFrom, target);
+            case replaceSpells -> doReplaceSpells(originKey, modInfo, copyFrom, target);
+            case removeSpells -> doRemoveSpells(originKey, modInfo, copyFrom, target);
+            case scalarMultXp -> doScalarMultXp(originKey, modInfo, target);
+            default -> {
+                return false;
+            }
+        }
+        return true;
     }
 
     ArrayNode sortArrayNode(ArrayNode array) {
@@ -554,101 +251,6 @@ public class JsonSourceCopier implements JsonSource {
         ArrayNode sorted = mapper().createArrayNode();
         sorted.addAll(elements);
         return sorted;
-    }
-
-    private void doSetProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
-        List<String> propPath = List.of(MetaFields.prop.getTextOrEmpty(modInfo).split("\\."));
-        if (!"*".equals(prop)) {
-            propPath = new ArrayList<>(propPath);
-            propPath.add(0, prop);
-        }
-        String last = propPath.remove(propPath.size() - 1);
-
-        ObjectNode targetRw = ((ObjectNode) target).withObject("/" + String.join("/", propPath));
-        targetRw.set(last, copyNode(MetaFields.value.getFrom(modInfo)));
-    }
-
-    private void doScalarAddHit(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
-        final Pattern hitPattern = Pattern.compile("\\{@hit ([-+]?\\d+)}");
-        if (!target.has(prop)) {
-            return;
-        }
-
-        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
-        String fullNode = hitPattern.matcher(target.get(prop).toString())
-                .replaceAll((match) -> "{@hit " + (Integer.parseInt(match.group(1)) + scalar) + "}");
-        target.set(prop, createNode(fullNode));
-    }
-
-    private void doScalarAddDc(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
-        final Pattern dcPattern = Pattern.compile("\\{@dc (\\d+)(?:\\|[^}]+)?}");
-        if (!target.has(prop)) {
-            return;
-        }
-        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
-        String fullNode = dcPattern.matcher(target.get(prop).toString())
-                .replaceAll((match) -> "{@dc " + (Integer.parseInt(match.group(1)) + scalar) + "}");
-        target.set(prop, createNode(fullNode));
-    }
-
-    private void doScalarAddProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
-        if (!target.has(prop)) {
-            return;
-        }
-        ObjectNode propRw = (ObjectNode) target.get(prop);
-        int scalar = MetaFields.scalar.getFrom(modInfo).asInt();
-        Consumer<String> scalarAdd = (k) -> {
-            JsonNode node = propRw.get(k);
-            boolean isString = node.isTextual();
-            int value = isString
-                    ? Integer.parseInt(node.asText())
-                    : node.asInt();
-            value += scalar;
-            propRw.replace(k, isString
-                    ? new TextNode(asModifier(value))
-                    : new IntNode(value));
-        };
-
-        String modProp = MetaFields.prop.getTextOrNull(modInfo);
-        if ("*".equals(modProp)) {
-            for (String fieldName : iterableFieldNames(propRw)) {
-                scalarAdd.accept(fieldName);
-            }
-        } else {
-            scalarAdd.accept(modProp);
-        }
-    }
-
-    private void doScalarMultProp(String originKey, JsonNode modInfo, String prop, ObjectNode target) {
-        if (!target.has(prop)) {
-            return;
-        }
-        ObjectNode propRw = (ObjectNode) target.get(prop);
-        double scalar = MetaFields.scalar.getFrom(modInfo).asDouble();
-        boolean floor = MetaFields.floor.booleanOrDefault(modInfo, false);
-        Consumer<String> scalarMult = (k) -> {
-            JsonNode node = propRw.get(k);
-            boolean isString = node.isTextual();
-            double value = isString
-                    ? Double.parseDouble(node.asText())
-                    : node.asDouble();
-            value *= scalar;
-            if (floor) {
-                value = Math.floor(value);
-            }
-            propRw.replace(k, isString
-                    ? new TextNode(asModifier(value))
-                    : new DoubleNode(value));
-        };
-
-        String modProp = MetaFields.prop.getTextOrNull(modInfo);
-        if ("*".equals(modProp)) {
-            for (String fieldName : iterableFieldNames(propRw)) {
-                scalarMult.accept(fieldName);
-            }
-        } else {
-            scalarMult.accept(modProp);
-        }
     }
 
     private void doScalarMultXp(String originKey, JsonNode modInfo, ObjectNode target) {
@@ -681,35 +283,6 @@ public class JsonSourceCopier implements JsonSource {
                 crNode = crNodeRw;
             }
             Tools5eFields.xp.setIn(crNode, new DoubleNode(scalarMult.applyAsDouble(crValue)));
-        }
-    }
-
-    private void doMaxSize(String originKey, JsonNode modInfo, ObjectNode target) {
-        final String SIZES = "FDTSMLHGCV";
-        if (!Tools5eFields.size.existsIn(target)) {
-            tui().errorf("Error (%s): enforcing maxSize on an object that does not define size; %s", originKey, target);
-            return;
-        }
-
-        String maxValue = MetaFields.max.getTextOrEmpty(modInfo);
-        int maxIdx = SIZES.indexOf(maxValue);
-        if (maxValue.isBlank() || maxIdx < 0) {
-            tui().errorf("Error (%s): Invalid maxSize value %s", originKey, maxValue.isBlank() ? "(missing)" : maxValue);
-            return;
-        }
-
-        ArrayNode size = Tools5eFields.size.ensureArrayIn(target);
-        List<JsonNode> collect = streamOf(size)
-                .filter(x -> SIZES.indexOf(x.asText()) <= maxIdx)
-                .collect(Collectors.toList());
-
-        if (size.size() != collect.size()) {
-            size.removeAll();
-            if (collect.isEmpty()) {
-                size.add(new TextNode(maxValue));
-            } else {
-                size.addAll(collect);
-            }
         }
     }
 
@@ -779,13 +352,13 @@ public class JsonSourceCopier implements JsonSource {
                 String k = i + "";
                 if (modSpells.has(k)) {
                     ArrayNode spellList = spells.withArray(k);
-                    appendToArray(spellList, (ArrayNode) modSpells.get(k));
+                    appendToArray(spellList, modSpells.get(k));
                 }
 
                 String each = i + "e";
                 if (modSpells.has(each)) {
                     ArrayNode spellList = spells.withArray(each);
-                    appendToArray(spellList, (ArrayNode) modSpells.get(each));
+                    appendToArray(spellList, modSpells.get(each));
                 }
             }
         }
@@ -961,202 +534,6 @@ public class JsonSourceCopier implements JsonSource {
         }
     }
 
-    void doModArray(String originKey, ModFieldMode mode, JsonNode modInfo, String prop, ObjectNode target) {
-        JsonNode items = ensureArray(MetaFields.items.getFrom(modInfo));
-        switch (mode) {
-            case prependArr -> {
-                ArrayNode tgtArray = target.withArray(prop);
-                insertIntoArray(tgtArray, 0, items);
-            }
-            case appendArr -> {
-                ArrayNode tgtArray = target.withArray(prop);
-                appendToArray(tgtArray, items);
-            }
-            case appendIfNotExistsArr -> {
-                ArrayNode tgtArray = target.withArray(prop);
-                appendIfNotExistsArr(tgtArray, items);
-            }
-            case insertArr -> {
-                if (!target.has(prop)) {
-                    tui().errorf("Error (%s): Unable to insert into array; %s is not present: %s", originKey, prop, target);
-                    return;
-                }
-                ArrayNode tgtArray = target.withArray(prop);
-                int index = MetaFields.index.intOrDefault(modInfo, -1);
-                if (index < 0) {
-                    index = tgtArray.size();
-                }
-                insertIntoArray(tgtArray, index, items);
-            }
-            case removeArr -> {
-                if (!target.has(prop)) {
-                    tui().errorf("Error (%s): Unable to remove from array; %s is not present: %s", originKey, prop, target);
-                    return;
-                }
-                ArrayNode tgtArray = target.withArray(prop);
-                removeFromArray(originKey, modInfo, prop, tgtArray);
-            }
-            case replaceArr -> {
-                if (!target.has(prop)) {
-                    tui().errorf("Error (%s): Unable to replace array; %s is not present: %s", originKey, prop, target);
-                    return;
-                }
-                ArrayNode tgtArray = target.withArray(prop);
-                replaceArray(originKey, modInfo, tgtArray, items);
-            }
-            case replaceOrAppendArr -> {
-                ArrayNode tgtArray = target.withArray(prop);
-                boolean didReplace = false;
-                if (tgtArray.size() > 0) {
-                    didReplace = replaceArray(originKey, modInfo, tgtArray, items);
-                }
-                if (!didReplace) {
-                    appendToArray(tgtArray, items);
-                }
-            }
-            default -> tui().errorf("Error (%s): Unknown modification mode for property %s: %s", originKey, prop, modInfo);
-        }
-    }
-
-    void appendToArray(ArrayNode tgtArray, JsonNode items) {
-        if (items == null) {
-            return;
-        }
-        if (items.isArray()) {
-            tgtArray.addAll((ArrayNode) items);
-        } else {
-            tgtArray.add(items);
-        }
-    }
-
-    void insertIntoArray(ArrayNode tgtArray, int index, JsonNode items) {
-        if (items == null) {
-            return;
-        }
-        if (items.isArray()) {
-            // iterate backwards so that items end up in the right order @ desired index
-            for (int i = items.size() - 1; i >= 0; i--) {
-                tgtArray.insert(index, items.get(i));
-            }
-        } else {
-            tgtArray.insert(index, items);
-        }
-    }
-
-    void appendIfNotExistsArr(ArrayNode tgtArray, JsonNode items) {
-        if (items == null) {
-            return;
-        }
-        if (tgtArray.size() == 0) {
-            appendToArray(tgtArray, items);
-        } else {
-            // Remove inbound items that already exist in the target array
-            // Use anyMatch to stop filtering ASAP
-            List<JsonNode> filtered = streamOf(items)
-                    .filter(it -> !streamOf(tgtArray).anyMatch(it::equals))
-                    .collect(Collectors.toList());
-            tgtArray.addAll(filtered);
-        }
-    }
-
-    void removeFromArray(String originKey, JsonNode modInfo, String prop, ArrayNode tgtArray) {
-        JsonNode names = ensureArray(MetaFields.names.getFrom(modInfo));
-        JsonNode items = ensureArray(MetaFields.items.getFrom(modInfo));
-        if (names != null) {
-            for (JsonNode name : iterableElements(names)) {
-                int index = findIndexByName(originKey, tgtArray, name.asText());
-                if (index >= 0) {
-                    tgtArray.remove(index);
-                } else if (!MetaFields.force.booleanOrDefault(modInfo, false)) {
-                    tui().errorf("Error (%s / %s): Unable to remove %s; %s", originKey, prop, name.asText(), modInfo);
-                }
-            }
-        } else if (items != null) {
-            removeFromArr(tgtArray, items);
-        } else {
-            tui().errorf("Error (%s / %s): One of names or items must be provided to remove elements from array; %s", originKey,
-                    prop, modInfo);
-        }
-    }
-
-    void removeFromArr(ArrayNode tgtArray, JsonNode items) {
-        for (JsonNode itemToRemove : iterableElements(items)) {
-            int index = findIndex(tgtArray, itemToRemove);
-            if (index >= 0) {
-                tgtArray.remove(index);
-            }
-        }
-    }
-
-    boolean replaceArray(String originKey, JsonNode modInfo, ArrayNode tgtArray, JsonNode items) {
-        if (items == null || !items.isArray()) {
-            return false;
-        }
-        JsonNode replace = MetaFields.replace.getFrom(modInfo);
-
-        final int index;
-        if (replace.isTextual()) {
-            index = findIndexByName(originKey, tgtArray, replace.asText());
-        } else if (replace.isObject() && MetaFields.index.existsIn(replace)) {
-            index = MetaFields.index.intOrDefault(replace, 0);
-        } else if (replace.isObject() && MetaFields.regex.existsIn(replace)) {
-            Pattern pattern = Pattern.compile("\\b" + MetaFields.regex.getTextOrEmpty(replace));
-            index = matchFirstIndexByName(originKey, tgtArray, pattern);
-        } else {
-            tui().errorf("Error (%s): Unknown replace; %s", originKey, modInfo);
-            return false;
-        }
-
-        if (index >= 0) {
-            tgtArray.remove(index);
-            insertIntoArray(tgtArray, index, items);
-            return true;
-        }
-        return false;
-    }
-
-    int matchFirstIndexByName(String originKey, ArrayNode haystack, Pattern needle) {
-        for (int i = 0; i < haystack.size(); i++) {
-            final String toMatch;
-            if (haystack.get(i).isObject()) {
-                toMatch = SourceField.name.getTextOrEmpty(haystack.get(i));
-            } else if (haystack.get(i).isTextual()) {
-                toMatch = haystack.asText();
-            } else {
-                continue;
-            }
-            if (!toMatch.isBlank() && needle.matcher(toMatch).find()) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    int findIndexByName(String originKey, ArrayNode haystack, String needle) {
-        for (int i = 0; i < haystack.size(); i++) {
-            final String toMatch;
-            if (haystack.get(i).isObject()) {
-                toMatch = SourceField.name.getTextOrEmpty(haystack.get(i));
-            } else if (haystack.get(i).isTextual()) {
-                toMatch = haystack.get(i).asText();
-            } else {
-                continue;
-            }
-            if (needle.equals(toMatch)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    int findIndex(ArrayNode haystack, JsonNode needle) {
-        for (int i = 0; i < haystack.size(); i++) {
-            if (haystack.get(i).equals(needle)) {
-                return i;
-            }
-        }
-        return -1;
-    }
 
     private String getShortName(JsonNode target, boolean isTitleCase) {
         String name = SourceField.name.getTextOrEmpty(target);
@@ -1223,124 +600,5 @@ public class JsonSourceCopier implements JsonSource {
                 return "cha";
         }
         throw new IllegalArgumentException("Unknown skill: " + skill);
-    }
-
-    enum MetaFields implements JsonNodeReader {
-        _copy,
-        _copiedFrom, // mind
-        _mod,
-        _preserve,
-        _root,
-        _trait,
-        alias,
-        apply,
-        data,
-        dex,
-        dex_mod,
-        flags,
-        floor,
-        force,
-        index,
-        items,
-        joiner,
-        max,
-        mode,
-        names,
-        overwrite,
-        prof_bonus,
-        prop,
-        props,
-        range,
-        regex,
-        replace,
-        root,
-        scalar,
-        skills,
-        str,
-        type,
-        value,
-        with,
-        ;
-    }
-
-    enum TemplateVariable implements JsonNodeReader.FieldValue {
-        name,
-        short_name,
-        title_short_name,
-        dc,
-        spell_dc,
-        to_hit,
-        damage_mod,
-        damage_avg;
-
-        @Override
-        public String value() {
-            return name();
-        }
-
-        public void notSupported(Tui tui, String originKey, JsonNode variableText) {
-            tui.errorf("Error (%s): Support for %s must be implemented. Raise an issue with this message. Text: %s",
-                    originKey, this.value(), variableText);
-        }
-
-        static TemplateVariable valueFrom(String value) {
-            return Stream.of(TemplateVariable.values())
-                    .filter((t) -> t.matches(value))
-                    .findFirst().orElse(null);
-        }
-    }
-
-    enum ModFieldMode implements JsonNodeReader.FieldValue {
-        appendStr,
-        replaceName,
-        replaceTxt,
-
-        prependArr,
-        appendArr,
-        replaceArr,
-        replaceOrAppendArr,
-        appendIfNotExistsArr,
-        insertArr,
-        removeArr,
-
-        calculateProp,
-        scalarAddProp,
-        scalarMultProp,
-        setProp,
-
-        addSenses,
-        addSaves,
-        addSkills,
-        addAllSaves,
-        addAllSkills,
-
-        addSpells,
-        removeSpells,
-        replaceSpells,
-
-        maxSize,
-        scalarMultXp,
-        scalarAddHit,
-        scalarAddDc;
-
-        @Override
-        public String value() {
-            return name();
-        }
-
-        public void notSupported(Tui tui, String originKey, JsonNode modInfo) {
-            tui.errorf("Error (%s): %s must be implemented. Raise an issue with this message. modInfo: %s",
-                    originKey, this.value(), modInfo);
-        }
-
-        static ModFieldMode valueFrom(JsonNode source, JsonNodeReader field) {
-            String textOrNull = field.getTextOrNull(source);
-            if (textOrNull == null) {
-                return null;
-            }
-            return Stream.of(ModFieldMode.values())
-                    .filter((t) -> t.matches(textOrNull))
-                    .findFirst().orElse(null);
-        }
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/MagicVariant.java
@@ -101,7 +101,7 @@ public class MagicVariant implements JsonSource {
 
     /** Update / replace item with variants (where appropriate) */
     public List<Tuple> findSpecificVariants(Tools5eIndex index, Tools5eIndexType type,
-            String key, JsonNode genericVariant, JsonSourceCopier copier) {
+            String key, JsonNode genericVariant, Tools5eJsonSourceCopier copier) {
         // const specificVariants = Renderer.item._createSpecificVariants(baseItems, genericVariants);
         // const outSpecificVariants = Renderer.item._enhanceItems(specificVariants);
         List<Tuple> variants = new ArrayList<>();

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
@@ -389,6 +389,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                 .compile(subclassFeature_1 + allowed + subclassFeature_2 + allowed + subclassFeature_3 + allowed + "?");
     }
 
+    @Override
     public void prepare() {
         if (variantIndex != null || filteredIndex != null) {
             return;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
@@ -74,7 +74,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
     private final Set<String> srdKeys = new HashSet<>();
     private final Set<String> familiarKeys = new HashSet<>();
 
-    final JsonSourceCopier copier = new JsonSourceCopier(this);
+    final Tools5eJsonSourceCopier copier = new Tools5eJsonSourceCopier(this);
 
     Pattern classFeaturePattern;
     Pattern subclassFeaturePattern;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndexType.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndexType.java
@@ -124,6 +124,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
         return fromText(typeKey);
     }
 
+    @Override
     public String createKey(JsonNode x) {
         if (this == book || this == adventure || this == bookData || this == adventureData) {
             String id = SourceField.id.getTextOrEmpty(x);
@@ -233,6 +234,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
         }
     }
 
+    @Override
     public String createKey(String name, String source) {
         if (source == null) {
             return String.format("%s|%s", this.name(), name).toLowerCase();

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eJsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eJsonSourceCopier.java
@@ -21,10 +21,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import dev.ebullient.convert.tools.JsonCopyException;
+import dev.ebullient.convert.tools.JsonSourceCopier;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteMonster.MonsterFields;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteRace.RaceFields;
 
-public class JsonSourceCopier extends dev.ebullient.convert.tools.JsonSourceCopier<Tools5eIndexType> implements JsonSource {
+public class Tools5eJsonSourceCopier extends JsonSourceCopier<Tools5eIndexType> implements JsonSource {
     static final Map<Tools5eIndexType, List<String>> _MERGE_REQUIRES_PRESERVE = Map.of(
             Tools5eIndexType.monster, List.of("legendaryGroup", "environment", "soundClip",
                     "altArt", "variant", "dragonCastingColor", "familiar"),
@@ -44,7 +45,7 @@ public class JsonSourceCopier extends dev.ebullient.convert.tools.JsonSourceCopi
 
     final Tools5eIndex index;
 
-    JsonSourceCopier(Tools5eIndex index) {
+    Tools5eJsonSourceCopier(Tools5eIndex index) {
         this.index = index;
     }
 

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndex.java
@@ -38,7 +38,7 @@ public class Pf2eIndex implements ToolsIndex, JsonSource {
     private final Map<String, Set<String>> archetypeToFeats = new TreeMap<>();
     private final Map<String, Set<String>> domainToSpells = new TreeMap<>();
 
-    final JsonSourceCopier copier = new JsonSourceCopier(this);
+    final Pf2eJsonSourceCopier copier = new Pf2eJsonSourceCopier(this);
 
     public Pf2eIndex(CompendiumConfig config) {
         this.config = config;

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndex.java
@@ -301,6 +301,10 @@ public class Pf2eIndex implements ToolsIndex, JsonSource {
         return traitToSource.get(trait.toLowerCase());
     }
 
+    public JsonNode getOrigin(String key) {
+        return imported.getOrDefault(key, null);
+    }
+
     @Override
     public JsonNode getAdventure(String a) {
         // TODO Auto-generated method stub

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndexType.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eIndexType.java
@@ -107,6 +107,7 @@ public enum Pf2eIndexType implements IndexType, JsonNodeReader {
         return valueOf(typeKey);
     }
 
+    @Override
     public String createKey(JsonNode node) {
         if (this == book || this == adventure) {
             String id = SourceField.id.getTextOrEmpty(node);
@@ -118,6 +119,7 @@ public enum Pf2eIndexType implements IndexType, JsonNodeReader {
         return String.format("%s|%s|%s", this.name(), name, source).toLowerCase();
     }
 
+    @Override
     public String createKey(String name, String source) {
         if (source == null || this == data) {
             return String.format("%s|%s", this.name(), name).toLowerCase();

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eJsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eJsonSourceCopier.java
@@ -1,8 +1,12 @@
 package dev.ebullient.convert.tools.pf2e;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.ebullient.convert.tools.JsonSourceCopier;
 
-public class Pf2eJsonSourceCopier implements JsonSource {
+import java.util.List;
+
+public class Pf2eJsonSourceCopier extends JsonSourceCopier<Pf2eIndexType> implements JsonSource {
     final Pf2eIndex index;
 
     Pf2eJsonSourceCopier(Pf2eIndex index) {
@@ -15,12 +19,34 @@ public class Pf2eJsonSourceCopier implements JsonSource {
     }
 
     @Override
-    public Pf2eSources getSources() {
-        throw new IllegalStateException("Should not call getSources while copying source");
+    protected JsonNode getOriginNode(String key) {
+        return index.getOrigin(key);
     }
 
-    JsonNode handleCopy(Pf2eIndexType type, JsonNode jsonSource) {
+    @Override
+    protected String getExternalTemplateKey(JsonNode trait) {
+        // Not used in Pf2eTools data
+        return null;
+    }
 
-        return jsonSource;
+    @Override
+    protected JsonNode resolveTemplateVariable(
+            String originKey, JsonNode value, JsonNode target, TemplateVariable variableMode, List<String> params
+    ) {
+        // Not used in Pf2eTools data
+        return null;
+    }
+
+    @Override
+    protected boolean doModProp(
+        ModFieldMode mode, String originKey, JsonNode modInfo, JsonNode copyFrom, ObjectNode target
+    ) {
+        // Not used in Pf2eTools data
+        return false;
+    }
+
+    @Override
+    public Pf2eSources getSources() {
+        throw new IllegalStateException("Should not call getSources while copying source");
     }
 }

--- a/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eJsonSourceCopier.java
+++ b/src/main/java/dev/ebullient/convert/tools/pf2e/Pf2eJsonSourceCopier.java
@@ -2,10 +2,10 @@ package dev.ebullient.convert.tools.pf2e;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class JsonSourceCopier implements JsonSource {
+public class Pf2eJsonSourceCopier implements JsonSource {
     final Pf2eIndex index;
 
-    JsonSourceCopier(Pf2eIndex index) {
+    Pf2eJsonSourceCopier(Pf2eIndex index) {
         this.index = index;
     }
 

--- a/src/test/java/dev/ebullient/convert/tools/dnd5e/RegexTest.java
+++ b/src/test/java/dev/ebullient/convert/tools/dnd5e/RegexTest.java
@@ -28,7 +28,7 @@ public class RegexTest implements JsonSource {
     @Test
     public void testToHitStr() {
         String s = " +<$to_hit__str$> ";
-        Matcher m = JsonSourceCopier.variable_subst.matcher(s);
+        Matcher m = Tools5eJsonSourceCopier.variable_subst.matcher(s);
         assertThat(m.find()).isTrue();
         assertThat(m.group("variable")).isEqualTo("to_hit__str");
         String[] pieces = m.group("variable").split("__");
@@ -38,7 +38,7 @@ public class RegexTest implements JsonSource {
     @Test
     public void testDamageAvg() {
         String s = "2.5+str";
-        Matcher m = JsonSourceCopier.dmg_avg_subst.matcher(s);
+        Matcher m = Tools5eJsonSourceCopier.dmg_avg_subst.matcher(s);
         assertThat(m.matches()).describedAs("damage_avg regex should match " + s).isTrue();
         assertThat(m.group(1)).isEqualTo("2.5");
         assertThat(m.group(2)).isEqualTo("+");


### PR DESCRIPTION
This is rebased off of #471 - will clean this up after that's merged in.

This moves a bunch of the DnD 5e JsonSourceCopier functionality into a common abstract class, with all of the DnD 5e specific content being provided via method overrides. There's space for Pf2e specific content to be provided with overrides as well, but honestly there isn't really much there. The Pf2eTools data is much less specific about what gets changed with the _copy modifiers at present.

I've used diffs to check that I haven't accidentally changed any 5e note output.