### PR TITLE
(WIP) Initial commit to allow for parsing of 5.24 content

### DIFF
--- a/src/main/java/dev/ebullient/convert/RpgDataConvertCli.java
+++ b/src/main/java/dev/ebullient/convert/RpgDataConvertCli.java
@@ -56,12 +56,12 @@ import picocli.CommandLine.UnmatchedArgumentException;
         "",
         "{",
         "  \"from\" : [",
-        "    \"PHB\",",
+        "    \"XPHB\",",
         "    \"DMG\",",
         "    \"SCAG\",",
         "  ]",
         "  \"exclude\" : [",
-        "    \"background|sage|phb\",",
+        "    \"background|sage|xphb\",",
         "  ]",
         "  \"excludePattern\" : [",
         "    \"race|.*|dmg\",",
@@ -113,7 +113,7 @@ public class RpgDataConvertCli implements Callable<Integer>, QuarkusApplication 
     Path configPath;
 
     @Option(names = "-s", hidden = true, description = "Source Books%n  " +
-            "Comma-separated list or multiple declarations (PHB,DMG,...); use ALL for all sources")
+            "Comma-separated list or multiple declarations (XPHB,DMG,...); use ALL for all sources")
     List<String> source = Collections.emptyList();
 
     @Option(names = "--index", description = "Create index of keys that can be used to exclude entries")

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/ItemMastery.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/ItemMastery.java
@@ -1,0 +1,162 @@
+package dev.ebullient.convert.tools.dnd5e;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import dev.ebullient.convert.io.Tui;
+import dev.ebullient.convert.tools.JsonTextConverter.SourceField;
+import dev.ebullient.convert.tools.dnd5e.JsonSource.Tools5eFields;
+import io.quarkus.qute.TemplateData;
+
+public interface ItemMastery {
+    static final Map<ItemMastery, String> masteryToLink = new HashMap<>();
+
+    Comparator<ItemMastery> comparator = Comparator.comparing(ItemMastery::value);
+
+    String getMarkdownLink(Tools5eIndex index);
+
+    String tagValue();
+
+    String value();
+
+    class CustomItemMastery implements ItemMastery {
+        final String name;
+        final String tag;
+
+        public CustomItemMastery(JsonNode mastery) {
+            String name = SourceField.name.getTextOrNull(mastery);
+            if (name == null) {
+                JsonNode entries = SourceField.entries.existsIn(mastery)
+                        ? SourceField.entries.getFrom(mastery)
+                        : Tools5eFields.entriesTemplate.getFrom(mastery);
+
+                if (entries != null && entries.size() > 0) {
+                    JsonNode firstEntry = entries.get(0);
+                    if (firstEntry.has("name")) {
+                        name = firstEntry.get("name").asText();
+                    }
+                }
+
+                if (name == null) {
+                    throw new IllegalArgumentException("Unable to get name for Mastery: " + mastery.toPrettyString());
+                }
+            }
+
+            this.name = name;
+            this.tag = "mastery/" + Tui.slugify(name);
+        }
+
+        public CustomItemMastery(String name) {
+            this.name = name;
+            this.tag = "mastery/" + Tui.slugify(name);
+        }
+
+        @Override
+        public String getMarkdownLink(Tools5eIndex index) {
+            return masteryToLink.computeIfAbsent(this, p -> {
+                List<JsonNode> targets = index.elementsMatching(Tools5eIndexType.itemMastery, name.toLowerCase());
+                if (targets.isEmpty() || targets.size() > 1) {
+                    return name;
+                }
+                String key = Tools5eIndexType.itemMastery.createKey(targets.get(0));
+
+                return index.isIncluded(key)
+                        ? String.format("[%s](%s)", name,
+                                index.rulesVaultRoot() + "item-mastery.md#" + index.toAnchorTag(name))
+                        : name;
+            });
+        }
+
+        @Override
+        public String tagValue() {
+            return tag;
+        }
+
+        @Override
+        public String value() {
+            return name;
+        }
+    }
+
+    @TemplateData
+    enum MasteryEnum implements ItemMastery {
+        CLEAVE("Cleave", "mastery/cleave"),
+        GRAZE("Graze", "mastery/graze"),
+        NICK("Nick", "mastery/nick"),
+        PUSH("Push", "mastery/push"),
+        SAP("Sap", "mastery/sap"),
+        SLOW("Slow", "mastery/slow"),
+        TOPPLE("Topple", "mastery/topple"),
+        VEX("Vex", "mastery/vex");
+
+        public final String name;
+        private final String tagValue;
+
+        MasteryEnum(String name, String tagValue) {
+            this.name = name;
+            this.tagValue = tagValue;
+        }
+
+        private static final List<MasteryEnum> knownProperties = Stream.of(MasteryEnum.values())
+                .collect(Collectors.toList());
+
+        public static boolean homebrewMastery(ItemMastery p) {
+            return !knownProperties.contains(p);
+        }
+
+        public String value() {
+            return name.toLowerCase();
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+
+        public String getMarkdownLink(Tools5eIndex index) {
+            return masteryToLink.computeIfAbsent(this, p -> {
+                List<JsonNode> targets = index.elementsMatching(Tools5eIndexType.itemMastery, name.toLowerCase());
+                if (targets.isEmpty() || targets.size() > 1) {
+                    return name;
+                }
+                String key = Tools5eIndexType.itemMastery.createKey(targets.get(0));
+
+                return index.isIncluded(key)
+                        ? String.format("[%s](%s)", name,
+                                index.rulesVaultRoot() + "item-mastery.md#" + index.toAnchorTag(name))
+                        : name;
+            });
+        }
+
+        public static MasteryEnum fromValue(String v) {
+            if (v == null || v.isBlank()) {
+                return null;
+            }
+            String key = v.toLowerCase();
+            for (MasteryEnum p : MasteryEnum.values()) {
+                if (p.name.toLowerCase().equals(key)) {
+                    return p;
+                }
+            }
+            Tui.instance().errorf("Invalid/Unknown mastery %s", v);
+            return null;
+        }
+
+        public static MasteryEnum fromName(String v) {
+            if (v == null || v.isBlank()) {
+                return null;
+            }
+            for (MasteryEnum p : MasteryEnum.values()) {
+                if (p.name.equals(v) || p.name.toLowerCase().equals(v.toLowerCase())) {
+                    return p;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteClass.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteClass.java
@@ -412,7 +412,7 @@ public class Json2QuteClass extends Json2QuteCommon {
 
             Subclass sc = new Subclass();
             sc.subclassNode = resolved;
-            sc.parentClassSource = parentClassSource; // e.g. PHB or DMG
+            sc.parentClassSource = parentClassSource; // e.g. XPHB or DMG
             sc.parentKey = getSources().getKey();
             sc.shortName = resolved.get("shortName").asText();
             sc.sources = Tools5eSources.findSources(scKey);

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -1,9 +1,5 @@
 package dev.ebullient.convert.tools.dnd5e;
 
-import static dev.ebullient.convert.StringUtil.isPresent;
-import static dev.ebullient.convert.StringUtil.joinConjunct;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
-
 import java.nio.file.Path;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
@@ -24,6 +20,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import dev.ebullient.convert.StringUtil;
+import static dev.ebullient.convert.StringUtil.isPresent;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
 import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.qute.ImageRef;
 import dev.ebullient.convert.qute.NamedText;
@@ -503,6 +502,7 @@ public class Json2QuteCommon implements JsonSource {
                     case proficiency -> values.add(proficiencyPrereq(value));
                     case race -> values.add(racePrereq(value));
                     case spell -> values.add(spellPrereq(value));
+                    case optionalfeature -> values.add(featurePrereq(value));
                     // --- Boolean values ----
                     case psionics -> values.addAll(testBoolean(value,
                             replaceText("Psionic Talent feature or {@feat Wild Talent|UA2020PsionicOptionsRevisited} feat")));
@@ -1025,6 +1025,7 @@ public class Json2QuteCommon implements JsonSource {
         displayEntry, // inner field for display
         note, // field alongside other fields
         prerequisite, // prereq field itself
+        optionalfeature,
         unknown // catcher for unknown attributes (see #fromString())
     }
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -1,5 +1,9 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.isPresent;
+import static dev.ebullient.convert.StringUtil.joinConjunct;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
+
 import java.nio.file.Path;
 import java.text.Normalizer;
 import java.text.Normalizer.Form;
@@ -20,9 +24,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import dev.ebullient.convert.StringUtil;
-import static dev.ebullient.convert.StringUtil.isPresent;
-import static dev.ebullient.convert.StringUtil.joinConjunct;
-import static dev.ebullient.convert.StringUtil.toTitleCase;
 import dev.ebullient.convert.io.Tui;
 import dev.ebullient.convert.qute.ImageRef;
 import dev.ebullient.convert.qute.NamedText;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteSpell.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteSpell.java
@@ -246,15 +246,15 @@ public class Json2QuteSpell extends Json2QuteCommon {
         });
         if (classes.contains("Wizard")) {
             if (school == SpellSchool.SchoolEnum.Abjuration || school == SpellSchool.SchoolEnum.Evocation) {
-                String finalKey = Tools5eIndexType.getSubclassKey("Fighter", "PHB", "Eldritch Knight", "PHB");
+                String finalKey = Tools5eIndexType.getSubclassKey("Fighter", "XPHB", "Eldritch Knight", "XPHB");
                 if (index().isIncluded(finalKey)) {
-                    classes.add(getSubclass(tags, "Fighter", "PHB", "Eldritch Knight", "PHB", finalKey));
+                    classes.add(getSubclass(tags, "Fighter", "XPHB", "Eldritch Knight", "XPHB", finalKey));
                 }
             }
             if (school == SpellSchool.SchoolEnum.Enchantment || school == SpellSchool.SchoolEnum.Illusion) {
-                String finalKey = Tools5eIndexType.getSubclassKey("Rogue", "PHB", "Arcane Trickster", "PHB");
+                String finalKey = Tools5eIndexType.getSubclassKey("Rogue", "XPHB", "Arcane Trickster", "XPHB");
                 if (index().isIncluded(finalKey)) {
-                    classes.add(getSubclass(tags, "Rogue", "PHB", "Arcane Trickster", "PHB", finalKey));
+                    classes.add(getSubclass(tags, "Rogue", "XPHB", "Arcane Trickster", "XPHB", finalKey));
                 }
             }
         }

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonTextReplacement.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonTextReplacement.java
@@ -228,7 +228,7 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
 
             result = linkTo5eImgRepo.matcher(result).replaceAll((match) -> {
                 // External links to materials in the 5eTools image repo (usually pdf):
-                // {@5etoolsImg Players Handbook Cover|covers/PHB.webp}
+                // {@5etoolsImg Players Handbook Cover|covers/XPHB.webp}
                 // const fauxEntry = {
                 //     type: "link",
                 //     href: {
@@ -483,13 +483,13 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
     }
 
     default String linkifyRules(Tools5eIndexType type, String text, String rules) {
-        // {@condition stunned} assumes PHB by default,
-        // {@condition stunned|PHB} can have sources added with a pipe (not that it's ever useful),
-        // {@condition stunned|PHB|and optional link text added with another pipe}.",
+        // {@condition stunned} assumes XPHB by default,
+        // {@condition stunned|XPHB} can have sources added with a pipe (not that it's ever useful),
+        // {@condition stunned|XPHB|and optional link text added with another pipe}.",
 
         String[] parts = text.split("\\|");
         String heading = parts[0];
-        String source = parts.length > 1 ? parts[1] : "PHB";
+        String source = parts.length > 1 ? parts[1] : "XPHB";
         String linkText = parts.length > 2 ? parts[2] : heading;
 
         String key = index().getAliasOrDefault(type.createKey(heading, source));
@@ -510,10 +510,10 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
 
     default String linkify(Tools5eIndexType type, String s) {
         return switch (type) {
-            // {@background Charlatan} assumes PHB by default,
+            // {@background Charlatan} assumes XPHB by default,
             // {@background Anthropologist|toa} can have sources added with a pipe,
             // {@background Anthropologist|ToA|and optional link text added with another pipe}.",
-            // {@feat Alert} assumes PHB by default,
+            // {@feat Alert} assumes XPHB by default,
             // {@feat Elven Accuracy|xge} can have sources added with a pipe,
             // {@feat Elven Accuracy|xge|and optional link text added with another pipe}.",
             // {@deck Tarokka Deck|CoS|tarokka deck} // like items
@@ -521,20 +521,20 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
             // {@hazard russet mold|vgm} can have sources added with a pipe,
             // {@hazard russet mold|vgm|and optional link text added with another pipe}.",
             // {@item alchemy jug} assumes DMG by default,
-            // {@item longsword|phb} can have sources added with a pipe,
-            // {@item longsword|phb|and optional link text added with another pipe}.",
+            // {@item longsword|xphb} can have sources added with a pipe,
+            // {@item longsword|xphb|and optional link text added with another pipe}.",
             // {@legroup unicorn} assumes MM by default,
             // {@legroup balhannoth|MPMM} can have sources added with a pipe,
             // {@legroup balhannoth|MPMM|and optional link text added with another pipe}.",
             // {@object Ballista} assumes DMG by default,
             // {@object Ballista|DMG|and optional link text added with another pipe}.",
-            // {@optfeature Agonizing Blast} assumes PHB by default,
+            // {@optfeature Agonizing Blast} assumes XPHB by default,
             // {@optfeature Aspect of the Moon|xge} can have sources added with a pipe,
             // {@optfeature Aspect of the Moon|xge|and optional link text added with another pipe}.",
             // {@psionic Mastery of Force} assumes UATheMysticClass by default
             // {@psionic Mastery of Force|UATheMysticClass} can have sources added with a pipe
             // {@psionic Mastery of Force|UATheMysticClass|and optional link text added with another pipe}.",
-            // {@race Human} assumes PHB by default,
+            // {@race Human} assumes XPHB by default,
             // {@race Aasimar (Fallen)|VGM}
             // {@race Aasimar|DMG|racial traits for the aasimar}
             // {@race Aarakocra|eepc} can have sources added with a pipe,
@@ -543,12 +543,12 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
             // {@reward Blessing of Health} assumes DMG by default,
             // {@reward Blessing of Health} can have sources added with a pipe,
             // {@reward Blessing of Health|DMG|and optional link text added with another pipe}.",
-            // {@spell acid splash} assumes PHB by default,
+            // {@spell acid splash} assumes XPHB by default,
             // {@spell tiny servant|xge} can have sources added with a pipe,
             // {@spell tiny servant|xge|and optional link text added with another pipe}.",
             // {@table 25 gp Art Objects} assumes DMG by default,
-            // {@table Adventuring Gear|phb} can have sources added with a pipe,
-            // {@table Adventuring Gear|phb|and optional link text added with another pipe}.",
+            // {@table Adventuring Gear|xphb} can have sources added with a pipe,
+            // {@table Adventuring Gear|xphb|and optional link text added with another pipe}.",
             // {@trap falling net} assumes DMG by default,
             // {@trap falling portcullis|xge} can have sources added with a pipe,
             // {@trap falling portcullis|xge|and optional link text added with another pipe}.",
@@ -643,13 +643,13 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
     }
 
     default String linkifyDeity(String match) {
-        // "Deities: {@deity Gond} assumes PHB Forgotten Realms pantheon by default,
+        // "Deities: {@deity Gond} assumes XPHB Forgotten Realms pantheon by default,
         // {@deity Gruumsh|nonhuman} can have pantheons added with a pipe,
         // {@deity Ioun|dawn war|dmg} can have sources added with another pipe,
         // {@deity Ioun|dawn war|dmg|and optional link text added with another pipe}.",
         String[] parts = match.split("\\|");
         String deity = parts[0];
-        String source = "phb";
+        String source = "xphb";
         String linkText = deity;
         String pantheon = "Faerûnian";
 
@@ -669,16 +669,16 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
     }
 
     default String linkifyClass(String match) {
-        // {@class fighter} assumes PHB by default,
+        // {@class fighter} assumes XPHB by default,
         // {@class artificer|uaartificer} can have sources added with a pipe,
-        // {@class fighter|phb|optional link text added with another pipe},
-        // {@class fighter|phb|subclasses added|Eldritch Knight} with another pipe,
-        // {@class fighter|phb|and class feature added|Eldritch Knight|phb|2-0} with another pipe
-        // {@class Barbarian|phb|Path of the Ancestral Guardian|Ancestral Guardian|xge}
-        // {@class Fighter|phb|Samurai|Samurai|xge}
+        // {@class fighter|xphb|optional link text added with another pipe},
+        // {@class fighter|xphb|subclasses added|Eldritch Knight} with another pipe,
+        // {@class fighter|xphb|and class feature added|Eldritch Knight|xphb|2-0} with another pipe
+        // {@class Barbarian|xphb|Path of the Ancestral Guardian|Ancestral Guardian|xge}
+        // {@class Fighter|xphb|Samurai|Samurai|xge}
         String[] parts = match.split("\\|");
         String className = parts[0];
-        String classSource = parts.length < 2 || parts[1].isEmpty() ? "phb" : parts[1];
+        String classSource = parts.length < 2 || parts[1].isEmpty() ? "xphb" : parts[1];
         String linkText = parts.length < 3 || parts[2].isEmpty() ? className : parts[2];
         String subclass = parts.length < 4 || parts[3].isEmpty() ? null : parts[3];
         String subclassSource = parts.length < 5 || parts[4].isEmpty() ? classSource : parts[4];
@@ -687,7 +687,7 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
         if (subclass != null) {
             String key = index()
                     .getAliasOrDefault(Tools5eIndexType.getSubclassKey(className, classSource, subclass, subclassSource));
-            // "subclass|path of wild magic|barbarian|phb|"
+            // "subclass|path of wild magic|barbarian|xphb|"
             int first = key.indexOf('|');
             int second = key.indexOf('|', first + 1);
             subclass = key.substring(first + 1, second);
@@ -701,7 +701,7 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
     }
 
     default String linkifyClassFeature(String match) {
-        // "Class Features: Class source is assumed to be PHB, class feature source is assumed to be the same as class source"
+        // "Class Features: Class source is assumed to be XPHB, class feature source is assumed to be the same as class source"
         // {@classFeature Rage|Barbarian||1},
         // {@classFeature Infuse Item|Artificer|TCE|2},
         // {@classFeature Survival Instincts|Barbarian||2|UAClassFeatureVariants},
@@ -713,7 +713,7 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
             return linkText;
         }
         String className = parts[1];
-        String classSource = parts[2].isBlank() ? "phb" : parts[2];
+        String classSource = parts[2].isBlank() ? "xphb" : parts[2];
         String level = parts[3];
         if (parts.length > 5) {
             linkText = parts[5];
@@ -765,10 +765,10 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
         // {@subclassFeature Alchemist|Artificer|TCE|Alchemist|TCE|3},
         // {@subclassFeature Path of the Battlerager|Barbarian||Battlerager|SCAG|3},  --> "barbarian-path-of-the-... "
         // {@subclassFeature Blessed Strikes|Cleric||Life||8|UAClassFeatureVariants}, --> "-domain"
-        // {@subclassFeature Blessed Strikes|Cleric|PHB|Twilight|TCE|8|TCE}
+        // {@subclassFeature Blessed Strikes|Cleric|XPHB|Twilight|TCE|8|TCE}
         // {@subclassFeature Path of the Berserker|Barbarian||Berserker||3||optional display text}.
-        // Class source is assumed to be PHB.
-        // Subclass source is assumed to be PHB.
+        // Class source is assumed to be XPHB.
+        // Subclass source is assumed to be XPHB.
         // Subclass feature source is assumed to be the same as subclass source.",
         String[] parts = match.split("\\|");
         String linkText = parts[0];
@@ -777,7 +777,7 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
             return linkText;
         }
         String className = parts[1];
-        String classSource = parts[2].isBlank() ? "phb" : parts[2];
+        String classSource = parts[2].isBlank() ? "xphb" : parts[2];
         String subclass = parts[3];
         String subclassSource = parts[4].isBlank() ? classSource : parts[4];
         String level = parts[5];
@@ -794,8 +794,8 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
         }
 
         // look up alias for subclass so link is correct, e.g.
-        // "subclass|redemption|paladin|phb|" : "subclass|oath of redemption|paladin|phb|",
-        // "subclass|twilight|cleric|phb|tce"    : "subclass|twilight domain|cleric|phb|tce"
+        // "subclass|redemption|paladin|xphb|" : "subclass|oath of redemption|paladin|xphb|",
+        // "subclass|twilight|cleric|xphb|tce"    : "subclass|twilight domain|cleric|xphb|tce"
         String subclassKey = index()
                 .getAliasOrDefault(Tools5eIndexType.getSubclassKey(className, classSource, subclass, subclassSource));
         int first = subclassKey.indexOf('|');

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
@@ -31,6 +31,8 @@ import dev.ebullient.convert.qute.SourceAndPage;
 import dev.ebullient.convert.tools.JsonNodeReader;
 import dev.ebullient.convert.tools.MarkdownConverter;
 import dev.ebullient.convert.tools.ToolsIndex;
+import dev.ebullient.convert.tools.dnd5e.ItemMastery.CustomItemMastery;
+import dev.ebullient.convert.tools.dnd5e.ItemMastery.MasteryEnum;
 import dev.ebullient.convert.tools.dnd5e.ItemProperty.CustomItemProperty;
 import dev.ebullient.convert.tools.dnd5e.ItemProperty.PropertyEnum;
 import dev.ebullient.convert.tools.dnd5e.ItemType.CustomItemType;
@@ -697,9 +699,9 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                         }
                     }
                     if (!variantIndex.containsKey(reprintKey)) {
-                        reprintKey = aliases.get(reprintKey);
-                        if (reprintKey == null) {
-                            tui().errorf("Unable to find reprint of %s: %s", finalKey, reprint);
+                        String alias = aliases.get(reprintKey);
+                        if (alias == null) {
+                            tui().errorf("Unable to find reprint of %s: %s (Reprint key: %s)", finalKey, reprint, reprintKey);
                             return false;
                         }
                     }
@@ -804,6 +806,21 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
             return new CustomItemProperty(abbreviation);
         }
         return prop;
+    }
+
+    public ItemMastery findItemMastery(String name, Tools5eSources sources) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        if (name.contains("|")) {
+            name = name.split("\\|")[0];
+        }
+        ItemMastery mastery = MasteryEnum.fromName(name);
+        if (mastery == null) {
+            tui().errorf("Unknown mastery %s for %s", name, sources);
+            return new CustomItemMastery(name);
+        }
+        return mastery;
     }
 
     public ItemType findItemType(String abbreviation, Tools5eSources sources) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
@@ -51,10 +51,10 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
         return instance;
     }
 
-    // classfeature|ability score improvement|monk|phb|12
+    // classfeature|ability score improvement|monk|xphb|12
     static final String classFeature_1 = "classfeature\\|[^|]+\\|[^|]+\\|";
     static final String classFeature_2 = "\\|\\d+\\|?";
-    // subclassfeature|blessed strikes|cleric|phb|death|dmg|8|uaclassfeaturevariants
+    // subclassfeature|blessed strikes|cleric|xphb|death|dmg|8|uaclassfeaturevariants
     static final String subclassFeature_1 = "subclassfeature\\|[^|]+\\|[^|]+\\|";
     static final String subclassFeature_2 = "\\|[^|]+\\|";
     static final String subclassFeature_3 = "\\|\\d+\\|?";
@@ -451,7 +451,6 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                     variantIndex.remove(v.key);
                     tui().debugf("Removed %s from index", v.key);
                 }
-
                 JsonNode old = variantIndex.put(v.key, v.node);
                 if (old != null && !old.equals(v.node)) {
                     String message = String.format("Duplicate key: %s%nold: %s%nnew: %s", v.key, old, v.node);
@@ -530,9 +529,9 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                 String[] parts = srKey.split("\\|");
                 String source = SourceField.source.getTextOrThrow(sr);
                 final String lookupKey;
-                if (parts[1].contains("(")) { // "subrace|dwarf (duergar)|dwarf|phb|mtf"
+                if (parts[1].contains("(")) { // "subrace|dwarf (duergar)|dwarf|xphb|mtf"
                     lookupKey = String.format("race|%s|%s", parts[1], source).toLowerCase();
-                } else { // "subrace|half-elf|half-elf|phb"
+                } else { // "subrace|half-elf|half-elf|xphb"
                     if (parts[1].equals(parts[2])) {
                         lookupKey = String.format("race|%s|%s", parts[1], source).toLowerCase();
                     } else {
@@ -549,7 +548,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
     }
 
     private List<Tuple> findDeities(List<Tuple> allDeities) {
-        List<String> reverseOrder = List.of("dsotdq", "erlw", "mtf", "vgm", "scag", "dmg", "phb");
+        List<String> reverseOrder = List.of("dsotdq", "erlw", "mtf", "vgm", "scag", "dmg");
         List<Tuple> result = new ArrayList<>();
         Map<String, List<Tuple>> booklist = new HashMap<>();
 
@@ -642,7 +641,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                     }
                 }
                 for (Entry<String, JsonNode> sourceClassSubclassMap : iterableFields(spellMap.get("subclass"))) {
-                    String classSource = sourceClassSubclassMap.getKey(); // PHB, XGE, etc
+                    String classSource = sourceClassSubclassMap.getKey(); // XPHB, XGE, etc
                     if (!sourceIncluded(classSource)) {
                         // skip it
                         continue;
@@ -650,7 +649,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                     for (Entry<String, JsonNode> classMap : iterableFields(sourceClassSubclassMap.getValue())) {
                         String className = classMap.getKey(); // Bard, Cleric, etc
                         for (Entry<String, JsonNode> sourceSubclassMap : iterableFields(classMap.getValue())) {
-                            String subclassSource = sourceSubclassMap.getKey(); // PHB, XGE, etc
+                            String subclassSource = sourceSubclassMap.getKey(); // XPHB, XGE, etc
                             if (!sourceIncluded(subclassSource)) {
                                 // skip it
                                 continue;
@@ -1020,7 +1019,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
 
         // Special case for class features (match against constructed patterns)
         if (key.contains("classfeature|")) {
-            String featureKey = key.replace("||", "|phb|");
+            String featureKey = key.replace("||", "|xphb|");
             return classFeaturePattern.matcher(featureKey).matches() || subclassFeaturePattern.matcher(featureKey).matches();
         }
         // Familiars
@@ -1314,7 +1313,7 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                 case "AS:V2-UA" -> "UARSC";
                 case "MV:C2-UA" -> "UARCO";
                 case "OR" -> "UACDW";
-                default -> "PHB";
+                default -> "XPHB";
             };
         }
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndex.java
@@ -690,7 +690,8 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                 if (srcinc) {
                     Tools5eIndexType type = Tools5eIndexType.getTypeFromKey(finalKey);
                     String primarySource = jsonSource.get("source").asText().toLowerCase();
-                    String reprintKey = type + "|" + reprint.toLowerCase();
+                    String reprintKey = type + "|" + reprint;
+                    reprintKey = reprintKey.toLowerCase();
                     if (type == Tools5eIndexType.subrace && !variantIndex.containsKey(reprintKey)) {
                         reprintKey = Tools5eIndexType.race + "|" + reprint.toLowerCase();
                         if (!variantIndex.containsKey(reprintKey)) {
@@ -700,7 +701,10 @@ public class Tools5eIndex implements JsonSource, ToolsIndex {
                     if (!variantIndex.containsKey(reprintKey)) {
                         String alias = aliases.get(reprintKey);
                         if (alias == null) {
-                            tui().errorf("Unable to find reprint of %s: %s (Reprint key: %s)", finalKey, reprint, reprintKey);
+                            tui().warnf("Unable to find reprint of %s: %s (Reprint key: %s)", finalKey, reprint, reprintKey);
+                            String item = String.format("|%s|", reprintKey.split("\\|")[1]);
+                            tui().warnf("%s is present", variantIndex.keySet().stream().filter(key -> key.contains(item))
+                                    .collect(Collectors.toSet()).toString());
                             return false;
                         }
                     }

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndexType.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eIndexType.java
@@ -143,12 +143,12 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
 
         switch (this) {
             case classfeature -> {
-                String classSource = IndexFields.classSource.getTextOrDefault(x, "phb");
+                String classSource = IndexFields.classSource.getTextOrDefault(x, "xphb");
                 return String.format("%s|%s|%s|%s|%s%s",
                         this.name(),
                         name,
                         IndexFields.className.getTextOrEmpty(x),
-                        "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+                        "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
                         IndexFields.level.getTextOrEmpty(x),
                         source.equalsIgnoreCase(classSource) ? "" : "|" + source)
                         .toLowerCase();
@@ -189,11 +189,11 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
                 return String.format("%s|%s%s",
                         this.name(),
                         name,
-                        "phb".equalsIgnoreCase(source) ? "" : "|" + source)
+                        "xphb".equalsIgnoreCase(source) ? "" : "|" + source)
                         .toLowerCase();
             }
             case subclass -> {
-                String classSource = IndexFields.classSource.getTextOrDefault(x, "PHB");
+                String classSource = IndexFields.classSource.getTextOrDefault(x, "XPHB");
                 String scSource = SourceField.source.getTextOrDefault(x, classSource);
                 // subclass|subclassName|className|classSource|subclassSource
                 return String.format("%s|%s|%s|%s|%s",
@@ -205,21 +205,21 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
                         .toLowerCase();
             }
             case subclassFeature -> {
-                String classSource = IndexFields.classSource.getTextOrDefault(x, "PHB");
-                String scSource = IndexFields.subclassSource.getTextOrDefault(x, "PHB");
+                String classSource = IndexFields.classSource.getTextOrDefault(x, "XPHB");
+                String scSource = IndexFields.subclassSource.getTextOrDefault(x, "XPHB");
                 return String.format("%s|%s|%s|%s|%s|%s|%s%s",
                         this.name(),
                         name,
                         IndexFields.className.getTextOrEmpty(x).trim(),
-                        "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+                        "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
                         IndexFields.subclassShortName.getTextOrEmpty(x).trim(),
-                        "phb".equalsIgnoreCase(scSource) ? "" : scSource,
+                        "xphb".equalsIgnoreCase(scSource) ? "" : scSource,
                         IndexFields.level.getTextOrEmpty(x),
                         source.equalsIgnoreCase(scSource) ? "" : "|" + source)
                         .toLowerCase();
             }
             case subrace -> {
-                String raceSource = IndexFields.raceSource.getTextOrDefault(x, "PHB");
+                String raceSource = IndexFields.raceSource.getTextOrDefault(x, "XPHB");
                 return String.format("%s|%s|%s|%s%s",
                         this.name(),
                         name,
@@ -247,7 +247,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
             return String.format("%s|%s%s",
                     Tools5eIndexType.optionalfeature,
                     name,
-                    "phb".equalsIgnoreCase(source) ? "" : "|" + source)
+                    "xphb".equalsIgnoreCase(source) ? "" : "|" + source)
                     .toLowerCase();
         }
 
@@ -259,9 +259,9 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
             String[] parts = crossRef.trim().split("\s?\\|\\s?");
             // 0    name,
             // 1    IndexFields.className.getTextOrEmpty(x),
-            // 2    "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+            // 2    "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
             // 3    IndexFields.subclassShortName.getTextOrEmpty(x),
-            // 4    "phb".equalsIgnoreCase(scSource) ? "" : scSource,
+            // 4    "xphb".equalsIgnoreCase(scSource) ? "" : scSource,
             // 5    IndexFields.level.getTextOrEmpty(x),
             // 6    source.equalsIgnoreCase(scSource) ? "" : "|" + source)
             if (parts.length < 6) {
@@ -277,7 +277,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
             String[] parts = crossRef.trim().split("\s?\\|\\s?");
             // 0    name,
             // 1    IndexFields.className.getTextOrEmpty(x),
-            // 2    "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+            // 2    "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
             // 3    IndexFields.level.getTextOrEmpty(x),
             // 4    source.equalsIgnoreCase(classSource) ? "" : "|" + source)
             if (parts.length < 4) {
@@ -344,8 +344,8 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
 
     public static String getSubclassKey(String className, String classSource, String subclassName, String subclassSource) {
         if (classSource == null || classSource.isEmpty()) {
-            // phb stays in the subclass text reference (match allowed sources)
-            classSource = "phb";
+            // xphb stays in the subclass text reference (match allowed sources)
+            classSource = "xphb";
         }
         return String.format("%s|%s|%s|%s|%s",
                 Tools5eIndexType.subclass,
@@ -359,10 +359,10 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
     public static String getSubclassTextReference(String className, String classSource, String subclassName,
             String subclassSource, String text) {
         if (classSource == null || classSource.isEmpty()) {
-            // phb stays in the subclass text reference (match allowed sources)
-            classSource = "phb";
+            // xphb stays in the subclass text reference (match allowed sources)
+            classSource = "xphb";
         }
-        // {@class Fighter|phb|Samurai|Samurai|xge}
+        // {@class Fighter|xphb|Samurai|Samurai|xge}
         return String.format("%s|%s|%s|%s|%s",
                 className,
                 classSource,
@@ -377,7 +377,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
                 Tools5eIndexType.classfeature,
                 name,
                 className,
-                "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+                "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
                 level,
                 featureSource.equalsIgnoreCase(classSource) ? "" : "|" + featureSource)
                 .toLowerCase();
@@ -389,9 +389,9 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
                 Tools5eIndexType.subclassFeature,
                 name,
                 className,
-                "phb".equalsIgnoreCase(classSource) ? "" : classSource,
+                "xphb".equalsIgnoreCase(classSource) ? "" : classSource,
                 scShortName,
-                "phb".equalsIgnoreCase(scSource) ? "" : scSource,
+                "xphb".equalsIgnoreCase(scSource) ? "" : scSource,
                 level,
                 featureSource.equalsIgnoreCase(scSource) ? "" : "|" + featureSource)
                 .toLowerCase();
@@ -530,7 +530,7 @@ public enum Tools5eIndexType implements IndexType, JsonNodeReader {
             case charoption -> "MOT";
             case syntheticGroup -> null;
             case itemTypeAdditionalEntries -> "XGE";
-            default -> "PHB";
+            default -> "XPHB";
         };
     }
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eSources.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eSources.java
@@ -210,7 +210,7 @@ public class Tools5eSources extends CompendiumSources {
 
     @Override
     protected boolean datasourceFilter(String source) {
-        return !List.of("phb", "mm", "dmg").contains(source.toLowerCase());
+        return !List.of("xphb", "mm", "dmg").contains(source.toLowerCase());
     }
 
     public Optional<String> uaSource() {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteItem.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteItem.java
@@ -31,6 +31,8 @@ public class QuteItem extends Tools5eQuteBase {
     public final String range;
     /** Formatted string listing item's properties (with links to rules if the source is present) */
     public final String properties;
+    /** Formatted string listing the items mastery */
+    public final String mastery;
     /** Strength requirement as a numerical value, if applicable */
     public final Integer strengthRequirement;
     /** True if the item imposes a stealth penalty, if applicable */
@@ -50,7 +52,7 @@ public class QuteItem extends Tools5eQuteBase {
 
     public QuteItem(Tools5eSources sources, String name, String source, String detail,
             String armorClass, String damage, String damage2h,
-            String range, String properties, Integer strengthRequirement, boolean stealthPenalty,
+            String range, String properties, String mastery, Integer strengthRequirement, boolean stealthPenalty,
             String costGp, Integer costCp, Double weightLbs, String prerequisite,
             String text, List<ImageRef> images, List<Variant> variants, Tags tags) {
         super(sources, name, source, text, tags);
@@ -61,6 +63,7 @@ public class QuteItem extends Tools5eQuteBase {
         this.damage2h = damage2h;
         this.range = range;
         this.properties = properties;
+        this.mastery = mastery;
         this.strengthRequirement = strengthRequirement;
         this.stealthPenalty = stealthPenalty;
         this.cost = costGp;
@@ -112,6 +115,8 @@ public class QuteItem extends Tools5eQuteBase {
         public final String range;
         /** Formatted string listing item's properties (with links to rules if the source is present) */
         public final String properties;
+        /** Formatted string listing the items mastery */
+        public final String mastery;
         /** Strength requirement as a numerical value, if applicable */
         public final Integer strengthRequirement;
         /** True if the item imposes a stealth penalty, if applicable */
@@ -126,7 +131,7 @@ public class QuteItem extends Tools5eQuteBase {
         public final String prerequisite;
 
         public Variant(String name, String armorClass, String damage, String damage2h,
-                String range, String properties, Integer strengthRequirement, boolean stealthPenalty,
+                String range, String properties, String mastery, Integer strengthRequirement, boolean stealthPenalty,
                 String cost, Integer costCp, Double weightLbs, String prerequisite) {
             this.name = name;
             this.armorClass = armorClass;
@@ -134,6 +139,7 @@ public class QuteItem extends Tools5eQuteBase {
             this.damage2h = damage2h;
             this.range = range;
             this.properties = properties;
+            this.mastery = mastery;
             this.strengthRequirement = strengthRequirement;
             this.stealthPenalty = stealthPenalty;
             this.cost = cost;

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/Tools5eQuteBase.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/Tools5eQuteBase.java
@@ -58,7 +58,7 @@ public class Tools5eQuteBase extends QuteBase {
 
     private static String sourceIfNotDefault(String source, Tools5eIndexType type) {
         switch (source.toLowerCase()) {
-            case "phb":
+            case "xphb":
             case "mm":
             case "dmg":
                 return "";

--- a/src/main/resources/sourceMap.json
+++ b/src/main/resources/sourceMap.json
@@ -98,7 +98,7 @@
       "OotA": "Out of the Abyss",
       "OoW": "The Orrery of the Wanderer",
       "PaBTSO": "Phandelver and Below: The Shattered Obelisk",
-      "PHB": "Player's Handbook",
+      "PHB": "2014 Player's Handbook",
       "PiP": "Peril in Pinegrove",
       "PotA": "Princes of the Apocalypse",
       "PSA": "Plane Shift: Amonkhet",
@@ -231,7 +231,10 @@
       "WBtW": "The Wild Beyond the Witchlight",
       "WDH": "Waterdeep: Dragon Heist",
       "WDMM": "Waterdeep: Dungeon of the Mad Mage",
+      "XDMG": "2024 Dungeon Masters Guide",
       "XGE": "Xanathar's Guide to Everything",
+      "XMM": "2024 Monster Manual",
+      "XPHB": "2024 Player's Handbook",
       "XMtS": "X Marks the Spot"
     },
     "longToAbv": {

--- a/src/main/resources/templates/tools5e/item2md.txt
+++ b/src/main/resources/templates/tools5e/item2md.txt
@@ -30,6 +30,8 @@ aliases:
 - **Range**: {resource.range}
 {/if}{/if}{#if resource.properties }
 - **Properties**: {resource.properties}
+{/if}{#if resource.mastery }
+- **Mastery**: {resource.mastery}
 {/if}{#if resource.strengthRequirement }
 - **Strength**: Requires {resource.strengthRequirement} STR.
 {/if}{#if resource.stealthPenalty }


### PR DESCRIPTION
As discussed on the discord I made some changes for my own vault to get the project running again. There are a few issues remaining that I havent gotten to yet. Either because I don't know where to look or I simply haven't had time to dig in. There are four main issues remaining:

## Missing a few reprints of monsters and items. Seems to have something to do with summons.
Either not in the data or erroneously dropped.

## Missing item types errors. Namely types ‘F’, ‘I’, ‘V’.
Only 'I' looks to actually be missing. Perhaps this has something to do with the new masteries.

## Unknown prerequisites specifically for the Warlock class
Don't know what changed, haven't looked at this yet.

## Add proper string replacements for summoned monsters ex: {@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier} should be: Melee Attack Roll: Bonus equals your spell attack modifier
Most of the Statblocks coming from the new PHB are summoned creatures. I don't know how this was done with the earlier edition but there are ugly String replace keys in the spells and attacks of summoned creatures. I haven't found/decided on a good place to add these substitutions. Nor found an exhaustive list of the keys to be replaced. Shouldn't be too difficult though. On the topic of summoned creatures: The text for HP has substantially changed for a few summoned creatures. So much so that I don't think it's reasonable to parse in the current setup. I have removed some exceptions to keep the tool going and added TODOs so maybe I can revisit at a later date.

Obviously this isn't a full list of remaining bugs but the four main ones I'm looking at. Sharing right now for you to take an early look at the changes and perhaps you can indicate a good place to look for the remaining bugs. Hope I can find some time soon to finish this up into a release-able state. Any feedback is welcome!