### PR TITLE
🐛 Include source of base class in subclass file name only if it isn't the default source

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eLinkifier.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Tools5eLinkifier.java
@@ -379,14 +379,15 @@ public class Tools5eLinkifier {
 
     public String getSubclassResource(String subclass, String parentClass, String classSource, String subclassSource) {
         String parentFile = Tui.slugify(parentClass);
-        // FIXME: check updated default source
-        if ("xphb".equalsIgnoreCase(classSource)) {
+        String defaultSource = Tools5eIndexType.classtype.defaultOutputSource();
+        if (!classSource.equalsIgnoreCase(defaultSource) &&
+                (classSource.equalsIgnoreCase("phb") || classSource.equalsIgnoreCase("xphb"))) {
             // For the most part, all subclasses are derived from the basic classes.
             // There wasn't really a need to include the class source in the file name.
             // However, the XPHB has created duplicates of all of the base classes.
-            // So if the parent class is from the XPHB, we need to include that in the file
-            // name.
-            parentFile += "-xphb";
+            // So if the parent class is not from the default source, we need to include
+            // its source in the file name if it's from the PHB or XPHB.
+            parentFile += "-" + classSource;
         }
         return fixFileName(
                 parentFile + "-" + Tui.slugify(subclass),


### PR DESCRIPTION
Figured I'd try another one that seemed within my capability. I tried to make sure it maintained the original functionality before configurable default sources were added, but by all means call out any issues you may have.

Changes file name structure of subclass files to only include source of the base class if the base class isn't from the default source. Only applies to classes from `PHB` and `XPHB`. Fixes #729.