### PR TITLE
✨Update yaml statblocks to more closely match source material text formatting

### DIFF
--- a/src/main/java/dev/ebullient/convert/qute/NamedText.java
+++ b/src/main/java/dev/ebullient/convert/qute/NamedText.java
@@ -42,6 +42,12 @@ public class NamedText {
         this.nested = List.of();
     }
 
+    public NamedText(String name, String desc, Collection<NamedText> nested) {
+        this.name = name;
+        this.desc = desc;
+        this.nested = nested;
+    }
+
     public NamedText(String name, Collection<String> text, Collection<NamedText> nested) {
         this.name = name == null ? "" : name;
         String body = text == null ? "" : String.join("\n", text);

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -3,6 +3,7 @@ package dev.ebullient.convert.tools.dnd5e;
 import static dev.ebullient.convert.StringUtil.isPresent;
 import static dev.ebullient.convert.StringUtil.joinConjunct;
 import static dev.ebullient.convert.StringUtil.toOrdinal;
+import static dev.ebullient.convert.StringUtil.uppercaseFirst;
 
 import java.nio.file.Path;
 import java.text.Normalizer;
@@ -605,7 +606,7 @@ public class Json2QuteCommon implements JsonSource {
             JsonNode v = speedNode.get(k);
             JsonNode altV = alternate == null ? null : alternate.get(k);
             if (v != null) {
-                String prefix = "walk".equals(k) ? "" : k + " ";
+                String prefix = "walk".equals(k) ? "" : uppercaseFirst(k) + " ";
                 speed.add(prefix + speedValue(k, v, includeZeroWalk));
                 if (altV != null && altV.isArray()) {
                     altV.forEach(x -> speed.add(prefix + speedValue(k, x, includeZeroWalk)));
@@ -826,9 +827,9 @@ public class Json2QuteCommon implements JsonSource {
 
     private String textValue(VulnerabilityFields field, String text) {
         if (field == VulnerabilityFields.conditionImmune) {
-            return linkify(Tools5eIndexType.condition, text);
+            return linkify(Tools5eIndexType.condition, uppercaseFirst(text));
         }
-        return text;
+        return uppercaseFirst(text);
     }
 
     List<NamedText> collectSortedTraits(JsonNode array) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteMonster.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteMonster.java
@@ -1,5 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
+import static dev.ebullient.convert.StringUtil.uppercaseFirst;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -106,7 +108,7 @@ public class Json2QuteMonster extends Json2QuteCommon {
                 linkifier().decoratedName(type, rootNode),
                 getSourceText(sources),
                 isNpc,
-                size, creatureType, subtype, monsterAlignment(),
+                size, uppercaseFirst(creatureType), uppercaseFirst(subtype), monsterAlignment(),
                 acHp,
                 speed(Tools5eFields.speed.getFrom(rootNode)),
                 abilityScores,

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
@@ -4,6 +4,7 @@ import static dev.ebullient.convert.StringUtil.asModifier;
 import static dev.ebullient.convert.StringUtil.joinConjunct;
 import static dev.ebullient.convert.StringUtil.pluralize;
 import static dev.ebullient.convert.StringUtil.toTitleCase;
+import static dev.ebullient.convert.StringUtil.uppercaseFirst;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,9 +50,9 @@ public class QuteMonster extends Tools5eQuteBase {
     public final boolean isNpc;
     /** Creature size (capitalized) */
     public final String size;
-    /** Creature type (lowercase) */
+    /** Creature type (capitalized) */
     public final String type;
-    /** Creature subtype (lowercase) */
+    /** Creature subtype (capitalized) */
     public final String subtype;
     /** Creature alignment */
     public final String alignment;
@@ -370,15 +371,15 @@ public class QuteMonster extends Tools5eQuteBase {
         addUnlessEmpty(map, "damage_resistances", immuneResist.resist);
         addUnlessEmpty(map, "damage_immunities", immuneResist.immune);
         addUnlessEmpty(map, "condition_immunities", immuneResist.conditionImmune);
-        map.put("senses", (senses.isBlank() ? "" : senses + ", ") + "passive Perception " + passive);
+        map.put("senses", (senses.isBlank() ? "" : senses + ", ") + "Passive Perception " + passive);
         map.put("languages", languages);
         addUnlessEmpty(map, "cr", cr);
 
-        addUnlessEmpty(map, "traits", trait);
-        addUnlessEmpty(map, "actions", action);
-        addUnlessEmpty(map, "bonus_actions", bonusAction);
-        addUnlessEmpty(map, "reactions", reaction);
-        addUnlessEmpty(map, "legendary_actions", legendary);
+        addUnlessEmpty(map, "traits", punctuateTraitNames(trait));
+        addUnlessEmpty(map, "actions", punctuateTraitNames(action));
+        addUnlessEmpty(map, "bonus_actions", punctuateTraitNames(bonusAction));
+        addUnlessEmpty(map, "reactions", punctuateTraitNames(reaction));
+        addUnlessEmpty(map, "legendary_actions", punctuateTraitNames(legendary));
 
         if (legendaryGroup != null) {
             for (NamedText group : legendaryGroup) {
@@ -398,10 +399,7 @@ public class QuteMonster extends Tools5eQuteBase {
 
         // De-markdown-ify
         return Tui.quotedYaml().dump(map).trim()
-                .replaceAll("`", "")
-                .replaceAll("\\*([^*]+)\\*", "$1") // em
-                .replaceAll("\\*([^*]+)\\*", "$1") // bold
-                .replaceAll("\\*([^*]+)\\*", "$1"); // bold em
+                .replaceAll("`", "");
     }
 
     private String yamlMonsterName(boolean withSource) {
@@ -413,6 +411,22 @@ public class QuteMonster extends Tools5eQuteBase {
             }
         }
         return "";
+    }
+
+    private List<NamedText> punctuateTraitNames(List<NamedText> traits) {
+        if (traits.isEmpty()) {
+            return traits;
+        }
+        List<NamedText> namedTraits = new ArrayList<>();
+        for (NamedText trait : traits) {
+            if (!trait.name.isBlank() && !trait.name.endsWith(".")) {
+                NamedText nt = new NamedText(trait.name + ".", trait.desc, trait.nested);
+                namedTraits.add(nt);
+            } else {
+                namedTraits.add(trait);
+            }
+        }
+        return namedTraits;
     }
 
     /**
@@ -762,11 +776,11 @@ public class QuteMonster extends Tools5eQuteBase {
                         if (s.isSpecial()) {
                             String ability = s.ability();
                             if (ability != null) {
-                                map.put("name", ability);
+                                map.put("name", uppercaseFirst(ability));
                             }
                             map.put("desc", s.mapValue());
                         } else {
-                            map.put(s.ability().toLowerCase(), s.modifier());
+                            map.put(uppercaseFirst(s.ability().toLowerCase()), s.modifier());
                         }
                         return map;
                     })

--- a/src/test/java/dev/ebullient/convert/tools/dnd5e/CommonDataTests.java
+++ b/src/test/java/dev/ebullient/convert/tools/dnd5e/CommonDataTests.java
@@ -338,9 +338,6 @@ public class CommonDataTests {
                         break;
                     } else {
                         frontmatter.add(l);
-                        if (l.contains("*")) {
-                            errors.add(String.format("Found '*' in %s: %s", p, l));
-                        }
                         TestUtils.commonTests(p, l, errors);
                     }
                 }
@@ -396,9 +393,6 @@ public class CommonDataTests {
                         yaml = false; // end yaml block
                     } else if (yaml) {
                         statblock.add(l);
-                        if (l.contains("*")) {
-                            errors.add(String.format("Found '*' in %s: %s", p, l));
-                        }
                         if (l.contains("\"desc\": \"\"")) {
                             errors.add(String.format("Found empty description in %s: %s", p, l));
                         }


### PR DESCRIPTION
Changes include:

- Spellcasting line spacing fix mentioned in #748.
- Capitalization of creature types/subtypes, resistances/vulnerabilities/immunities, saves, and passive perception.
- Trait and action names now have punctuation to match source material.
- Trait and action descriptions now retain markdown text formatting (italics/bold) as the FS plugin appears to now support it.

As always, more than willing to adjust or revert any changes that don't quite fit what you'd prefer.