### PR TITLE
🐛 Make singular dice roll formats consistent with source material

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/JsonTextConverter.java
+++ b/src/main/java/dev/ebullient/convert/tools/JsonTextConverter.java
@@ -191,7 +191,7 @@ public interface JsonTextConverter<T extends IndexType> {
                 String[] alternatives = rollString.split(";");
                 if (displayText == null && alternatives.length > 1) {
                     for (int i = 0; i < alternatives.length; i++) {
-                        String coded = codeString(alternatives[i], formulaState, true);
+                        String coded = codeString(alternatives[i], formulaState);
                         alternatives[i] = formatDice(alternatives[i], coded, formulaState, true, false);
                     }
                     displayText = String.join(" or ", alternatives);
@@ -264,12 +264,7 @@ public interface JsonTextConverter<T extends IndexType> {
     }
 
     default String codeString(String text, DiceFormulaState formulaState) {
-        return codeString(text, formulaState, false);
-    }
-
-    default String codeString(String text, DiceFormulaState formulaState, boolean alternative) {
         if (text.matches("^1?d\\d+$")) {
-            text = alternative ? text : text.replace("1d", "d");
             return formulaState.plainText() ? text : "`%s`".formatted(text);
         }
         text = text.replace("1d20", "");
@@ -292,8 +287,8 @@ public interface JsonTextConverter<T extends IndexType> {
         if (text.contains("reach levels")) {
             // don't look for averages here. This is spell progression
         } else if (text.matches("^`dice:1?d\\d+\\|.*?` \\(`1?d\\d+`\\)")) {
-            text = text.replaceAll("^`dice:1?d(\\d+)\\|.*",
-                    "`dice:1d$1|noform|noparens|avg|text(d$1)`");
+            text = text.replaceAll("^`dice:(1)?d(\\d+)\\|.*",
+                    "`dice:1d$2|noform|noparens|avg|text($1d$2)`");
         } else {
             // otherwise look for average rolls
             // 7 (`dice:1d6+4|noform|avg` (`1d6 + 4`)) --> `dice:1d6+4|noform|avg|text(7)` (`1d6 + 4`)

--- a/src/test/java/dev/ebullient/convert/tools/dnd5e/TextReplacementTest.java
+++ b/src/test/java/dev/ebullient/convert/tools/dnd5e/TextReplacementTest.java
@@ -142,7 +142,7 @@ public class TextReplacementTest implements JsonSource {
                 "with extended display text (`+2`) and display text (`+2`)",
                 "a special 'hit' version which assumes a d20 is to be rolled `+7`",
                 "There's also `1d12+3` and `-4`",
-                "scaledamage: `d6`, scaledice: extra amount (`d6`)",
+                "scaledamage: `1d6`, scaledice: extra amount (`1d6`)",
                 "<span title='Strength'>`20` (`+5`)</span>, <span title='Strength'>`+5`</span>, and [Animal Handling](rules/skills.md#Animal%20Handling) (`+5`)",
                 "with an Intelligence of `+3` (`16`), a Wisdom of `+0` (`10`), and a Charisma of `+4` (`18`)",
                 "`+3 plus PB` to hit;  *Hit:* 7 (`1d6 + 4`) piercing damage plus 7 (`2d6`) poison damage.",
@@ -165,7 +165,7 @@ public class TextReplacementTest implements JsonSource {
                 "with extended `dice:1d20+2|noform|noparens|avg|text(display text)` (`+2`) and `dice:1d20+2|noform|noparens|avg|text(display text)` (`+2`)",
                 "a special 'hit' version which assumes a d20 is to be rolled `dice:1d20+7|noform|noparens|text(+7)`",
                 "There's also `dice:1d12+3|noform|noparens|avg` (`1d12+3`) and `dice:1d20-4|noform|noparens|text(-4)`",
-                "scaledamage: `dice:1d6|noform|noparens|avg|text(d6)`, scaledice: `dice:1d6|noform|noparens|avg|text(extra amount)` (`d6`)",
+                "scaledamage: `dice:1d6|noform|noparens|avg|text(1d6)`, scaledice: `dice:1d6|noform|noparens|avg|text(extra amount)` (`1d6`)",
                 "<span title='Strength'>`20` (`dice:d20+5|noform|noparens|text(+5)`)</span>, <span title='Strength'>`dice:d20+5|noform|noparens|text(+5)`</span>, and [Animal Handling](rules/skills.md#Animal%20Handling) (`dice:1d20+5|noform|noparens|text(+5)`)",
                 "with an Intelligence of `dice:1d20+3|noform|noparens|text(+3)` (`16`), a Wisdom of `dice:1d20+0|noform|noparens|text(+0)` (`10`), and a Charisma of `dice:1d20+4|noform|noparens|text(+4)` (`18`)",
                 "`+3 plus PB` to hit;  *Hit:* `dice:1d6+4|noform|noparens|avg|text(7)` (`1d6 + 4`) piercing damage plus `dice:2d6|noform|noparens|avg|text(7)` (`2d6`) poison damage.",
@@ -195,7 +195,7 @@ public class TextReplacementTest implements JsonSource {
                 "with extended display text (+2) and display text (+2)",
                 "a special 'hit' version which assumes a d20 is to be rolled +7",
                 "There's also 1d12+3 and -4",
-                "scaledamage: d6, scaledice: extra amount (d6)",
+                "scaledamage: 1d6, scaledice: extra amount (1d6)",
                 "<span title='Strength'>20 (+5)</span>, <span title='Strength'>+5</span>, and [Animal Handling](rules/skills.md#Animal%20Handling) (+5)",
                 "with an Intelligence of +3 (16), a Wisdom of +0 (10), and a Charisma of +4 (18)",
                 "+3 plus PB to hit;  *Hit:* 7 (1d6 + 4) piercing damage plus 7 (2d6) poison damage.",
@@ -250,25 +250,25 @@ public class TextReplacementTest implements JsonSource {
         String tag20 = "{@d20}";
 
         assertThat(this.replaceText(d20)).isEqualTo("`d20`");
-        assertThat(this.replaceText(oneD20)).isEqualTo("`d20`");
+        assertThat(this.replaceText(oneD20)).isEqualTo("`1d20`");
         assertThat(this.replaceText(tag20)).isEqualTo("`d20`");
 
         configurator.setUseDiceRoller(DiceRoller.enabled);
 
         assertThat(this.replaceText(d20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
-        assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
+        assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(1d20)`");
         assertThat(this.replaceText(tag20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
 
         configurator.setUseDiceRoller(DiceRoller.enabledUsingFS);
 
         assertThat(this.replaceText(d20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
-        assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
+        assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(1d20)`");
         assertThat(this.replaceText(tag20)).isEqualTo("`dice:1d20|noform|noparens|avg|text(d20)`");
 
         boolean pushed = parseState().pushMarkdownTable(true);
         try {
             assertThat(this.replaceText(d20)).isEqualTo("`dice:1d20\\|noform\\|noparens\\|avg\\|text(d20)`");
-            assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20\\|noform\\|noparens\\|avg\\|text(d20)`");
+            assertThat(this.replaceText(oneD20)).isEqualTo("`dice:1d20\\|noform\\|noparens\\|avg\\|text(1d20)`");
             assertThat(this.replaceText(tag20)).isEqualTo("`dice:1d20\\|noform\\|noparens\\|avg\\|text(d20)`");
         } finally {
             parseState().pop(pushed);
@@ -277,13 +277,13 @@ public class TextReplacementTest implements JsonSource {
         pushed = parseState().pushTrait();
         try {
             assertThat(this.replaceText(d20)).isEqualTo("d20");
-            assertThat(this.replaceText(oneD20)).isEqualTo("d20");
+            assertThat(this.replaceText(oneD20)).isEqualTo("1d20");
             assertThat(this.replaceText(tag20)).isEqualTo("d20");
 
             configurator.setUseDiceRoller(DiceRoller.disabledUsingFS);
 
             assertThat(this.replaceText(d20)).isEqualTo("d20");
-            assertThat(this.replaceText(oneD20)).isEqualTo("d20");
+            assertThat(this.replaceText(oneD20)).isEqualTo("1d20");
             assertThat(this.replaceText(tag20)).isEqualTo("d20");
         } finally {
             parseState().pop(pushed);
@@ -298,22 +298,22 @@ public class TextReplacementTest implements JsonSource {
         String oneD12 = "{@dice 1d12}";
 
         assertThat(this.replaceText(d12)).isEqualTo("`d12`");
-        assertThat(this.replaceText(oneD12)).isEqualTo("`d12`");
+        assertThat(this.replaceText(oneD12)).isEqualTo("`1d12`");
 
         configurator.setUseDiceRoller(DiceRoller.enabled);
 
         assertThat(this.replaceText(d12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(d12)`");
-        assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(d12)`");
+        assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(1d12)`");
 
         configurator.setUseDiceRoller(DiceRoller.enabledUsingFS);
 
         assertThat(this.replaceText(d12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(d12)`");
-        assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(d12)`");
+        assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12|noform|noparens|avg|text(1d12)`");
 
         boolean pushed = parseState().pushMarkdownTable(true);
         try {
             assertThat(this.replaceText(d12)).isEqualTo("`dice:1d12\\|noform\\|noparens\\|avg\\|text(d12)`");
-            assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12\\|noform\\|noparens\\|avg\\|text(d12)`");
+            assertThat(this.replaceText(oneD12)).isEqualTo("`dice:1d12\\|noform\\|noparens\\|avg\\|text(1d12)`");
         } finally {
             parseState().pop(pushed);
         }
@@ -321,12 +321,12 @@ public class TextReplacementTest implements JsonSource {
         pushed = parseState().pushTrait();
         try {
             assertThat(this.replaceText(d12)).isEqualTo("d12");
-            assertThat(this.replaceText(oneD12)).isEqualTo("d12");
+            assertThat(this.replaceText(oneD12)).isEqualTo("1d12");
 
             configurator.setUseDiceRoller(DiceRoller.disabledUsingFS);
 
             assertThat(this.replaceText(d12)).isEqualTo("d12");
-            assertThat(this.replaceText(oneD12)).isEqualTo("d12");
+            assertThat(this.replaceText(oneD12)).isEqualTo("1d12");
         } finally {
             parseState().pop(pushed);
         }


### PR DESCRIPTION
Resolves #758. Pretty simple but happy to adjust if you're still hesitant after our discussion.