### PR TITLE
✨ Sort classes list for spells and add feats, races, and backgrounds lists

### DIFF
--- a/docs/templates/dnd5e/QuteSpell.md
+++ b/docs/templates/dnd5e/QuteSpell.md
@@ -6,7 +6,11 @@ Extension of [Tools5eQuteBase](Tools5eQuteBase.md).
 
 ## Attributes
 
-[books](#books), [classList](#classlist), [classes](#classes), [components](#components), [duration](#duration), [fluffImages](#fluffimages), [hasImages](#hasimages), [hasMoreImages](#hasmoreimages), [hasSections](#hassections), [labeledSource](#labeledsource), [level](#level), [name](#name), [range](#range), [references](#references), [reprintOf](#reprintof), [ritual](#ritual), [school](#school), [showAllImages](#showallimages), [showMoreImages](#showmoreimages), [showPortraitImage](#showportraitimage), [source](#source), [sourceAndPage](#sourceandpage), [sourcesWithFootnote](#sourceswithfootnote), [tags](#tags), [text](#text), [time](#time), [vaultPath](#vaultpath)
+[backgrounds](#backgrounds), [books](#books), [classList](#classlist), [classes](#classes), [components](#components), [duration](#duration), [feats](#feats), [fluffImages](#fluffimages), [hasImages](#hasimages), [hasMoreImages](#hasmoreimages), [hasSections](#hassections), [labeledSource](#labeledsource), [level](#level), [name](#name), [optionalfeatures](#optionalfeatures), [races](#races), [range](#range), [references](#references), [reprintOf](#reprintof), [ritual](#ritual), [school](#school), [showAllImages](#showallimages), [showMoreImages](#showmoreimages), [showPortraitImage](#showportraitimage), [source](#source), [sourceAndPage](#sourceandpage), [sourcesWithFootnote](#sourceswithfootnote), [tags](#tags), [text](#text), [time](#time), [vaultPath](#vaultpath)
+
+### backgrounds
+
+String: rendered list of links to classes that grant access to this spell. May be incomplete or empty.
 
 ### books
 
@@ -27,6 +31,10 @@ Formatted: spell components
 ### duration
 
 Formatted: spell range
+
+### feats
+
+String: rendered list of links to feats that grant acccess to this spell. May be incomplete or empty.
 
 ### fluffImages
 
@@ -55,6 +63,14 @@ Spell level
 ### name
 
 Note name
+
+### optionalfeatures
+
+String: rendered list of links to optional features that grant access to this spell. May be incomplete or empty.
+
+### races
+
+String: rendered list of links to races that can use this spell. May be incomplete or empty.
 
 ### range
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteSpell.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteSpell.java
@@ -31,8 +31,16 @@ public class QuteSpell extends Tools5eQuteBase {
     public final String components;
     /** Formatted: spell range */
     public final String duration;
+    /** String: rendered list of links to classes that grant access to this spell. May be incomplete or empty. */
+    public final String backgrounds;
     /** String: rendered list of links to classes that can use this spell. May be incomplete or empty. */
     public final String classes;
+    /** String: rendered list of links to feats that grant acccess to this spell. May be incomplete or empty. */
+    public final String feats;
+    /** String: rendered list of links to optional features that grant access to this spell. May be incomplete or empty. */
+    public final String optionalfeatures;
+    /** String: rendered list of links to races that can use this spell. May be incomplete or empty. */
+    public final String races;
     /** List of links to resources (classes, subclasses, feats, etc.) that have access to this spell */
     public final Collection<String> references;
 
@@ -50,8 +58,31 @@ public class QuteSpell extends Tools5eQuteBase {
         this.components = components;
         this.duration = duration;
         this.references = references;
+        this.backgrounds = references.stream()
+                .filter(s -> s.contains("background"))
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("; "));
         this.classes = references.stream()
                 .filter(s -> s.contains("class"))
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("; "));
+        this.feats = references.stream()
+                .filter(s -> s.contains("feat"))
+                .filter(s -> !s.contains("optional-feature"))
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("; "));
+        this.optionalfeatures = references.stream()
+                .filter(s -> s.contains("optional-feature"))
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("; "));
+        this.races = references.stream()
+                .filter(s -> s.contains("race"))
+                .distinct()
+                .sorted()
                 .collect(Collectors.joining("; "));
     }
 


### PR DESCRIPTION
Snooped around and found an easy fix for sorting the `classes` resource for spells. Resolves #774 and also adds `backgrounds`, `feats`, `races`, and `optionalfeatures` as additional resources that list the links to any of those references that grant access to a given spell. As always, happy to adjust if any of this is more than you think is needed.