### PR TITLE
♻️ Allow homebrew optional features to use full type names

### DIFF
--- a/docs/sourceMap.md
+++ b/docs/sourceMap.md
@@ -104,7 +104,7 @@ _Support content creators. Only use or include sources that you own._
 | MCV1SC | Monstrous Compendium Volume 1: Spelljammer Creatures | reference |
 | MCV2DC | Monstrous Compendium Volume 2: Dragonlance Creatures | reference |
 | MCV3MC | Monstrous Compendium Volume 3: Minecraft Creatures | reference |
-| MCV4EC | Monstrous Compendium Volume 3: 4: Eldraine Creatures | book |
+| MCV4EC | Monstrous Compendium Volume 4: Eldraine Creatures | book |
 | MFF | Mordenkainen's Fiendish Folio | reference |
 | MGELFT | Muk's Guide To Everything He Learned From Tasha | reference |
 | MM | Monster Manual | book |

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -244,7 +244,7 @@ public class Json2QuteCommon implements JsonSource {
     private String replaceConjoinOr(JsonNode campaignPrereq, String suffix) {
         List<String> cmpn = new ArrayList<>();
         for (JsonNode p : iterableElements(campaignPrereq)) {
-            replaceText(p.asText());
+            cmpn.add(replaceText(p.asText()));
         }
         return joinConjunct(" or ", cmpn) + suffix;
     }
@@ -513,7 +513,7 @@ public class Json2QuteCommon implements JsonSource {
                     case culture -> values.add(replaceConjoinOr(value, " Culture"));
                     case expertise -> values.add(expertisePrereq(value));
                     case feat -> values.add(featPrereq(value));
-                    case feature -> values.add(replaceConjoinOr(value, ""));
+                    case feature -> values.add(replaceConjoinOr(value, " Feature"));
                     case optionalfeature -> values.add(replaceConjoinOr(value, ""));
                     case group -> values.add(replaceConjoinOr(value, " Group"));
                     case item -> values.add(replaceConjoinOr(value, ""));

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteFeat.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteFeat.java
@@ -25,11 +25,9 @@ public class Json2QuteFeat extends Json2QuteCommon {
 
         List<ImageRef> images = getFluffImages(Tools5eIndexType.featFluff);
 
-        String category = featureTypeToFull(FeatFields.category.getTextOrEmpty(rootNode));
-        if (category.equalsIgnoreCase("Fighting Style, Paladin")) {
-            category = "Fighting Style Replacement (Paladin)";
-        } else if (category.equalsIgnoreCase("Fighting Style, Ranger")) {
-            category = "Fighting Style Replacement (Ranger)";
+        String category = JsonSource.featureTypeToString(FeatFields.category.getTextOrEmpty(rootNode), null);
+        if (category.startsWith("Fighting Style, ")) {
+            category = "Fighting Style Replacement";
         }
 
         // Initialize full entries with ability score increases merged

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteOptionalFeature.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteOptionalFeature.java
@@ -23,7 +23,7 @@ public class Json2QuteOptionalFeature extends Json2QuteCommon {
             tags.add("optional-feature", featureType);
         }
 
-        String featureTypeFull = featureTypeToFull(typeList.get(0));
+        String featureTypeFull = index.getOptionalFeatureType(typeList.get(0)).getTitle();
         if (featureTypeFull.startsWith("Fighting Style")) {
             featureTypeFull = "Fighting Style"; //trim class name, fighting styles can be for multiple classes
         } else if (featureTypeFull.equalsIgnoreCase("Maneuver, Battle Master")) {

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
@@ -30,6 +30,7 @@ import dev.ebullient.convert.tools.JsonSourceCopier.MetaFields;
 import dev.ebullient.convert.tools.JsonTextConverter;
 import dev.ebullient.convert.tools.ParseState;
 import dev.ebullient.convert.tools.ToolsIndex.TtrpgValue;
+import dev.ebullient.convert.tools.dnd5e.HomebrewIndex.HomebrewMetaTypes;
 import dev.ebullient.convert.tools.dnd5e.Json2QuteClass.ClassFeature;
 import dev.ebullient.convert.tools.dnd5e.qute.Tools5eQuteBase;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -1299,11 +1300,7 @@ public interface JsonSource extends JsonTextReplacement {
         return String.join(", ", result);
     }
 
-    default String featureTypeToFull(String featureType) {
-        return featureTypeToString(featureType);
-    }
-
-    public static String featureTypeToString(String featureType) {
+    public static String featureTypeToString(String featureType, Map<String, HomebrewMetaTypes> homebrew) {
         if (!isPresent(featureType)) {
             return "";
         }
@@ -1332,10 +1329,15 @@ public interface JsonSource extends JsonTextReplacement {
             case "RN" -> "Rune Knight Rune";
             case "AF" -> "Alchemical Formula";
             case "TT" -> "Traveler's Trick";
-            case "BC" -> "Blood Curse";
-            case "CR" -> "Crimson Rite";
-            case "MTGN" -> "Mutagen";
-            default -> featureType;
+            default -> {
+                if (!homebrew.isEmpty()) {
+                    yield homebrew.values().stream()
+                            .map(hb -> hb.getOptionalFeatureType(featureType))
+                            .distinct()
+                            .collect(Collectors.joining("; "));
+                }
+                yield featureType;
+            }
         };
     };
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/OptionalFeatureIndex.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/OptionalFeatureIndex.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -268,14 +267,8 @@ public class OptionalFeatureIndex implements JsonSource {
         }
 
         public String getTitle() {
-            String title = JsonSource.featureTypeToString(abbreviation);
+            String title = JsonSource.featureTypeToString(abbreviation, homebrewMeta);
             if (title.equalsIgnoreCase(abbreviation)) {
-                if (!homebrewMeta.isEmpty()) {
-                    return homebrewMeta.values().stream()
-                            .map(hb -> hb.getOptionalFeatureType(abbreviation))
-                            .distinct()
-                            .collect(Collectors.joining("; "));
-                }
                 Tui.instance().warnf(Msg.NOT_SET, "Missing title for OptionalFeatureType in %s",
                         abbreviation);
                 return abbreviation;

--- a/src/main/resources/sourceMap.yaml
+++ b/src/main/resources/sourceMap.yaml
@@ -263,7 +263,7 @@ config5e:
       name: "Monstrous Compendium Volume 3: Minecraft Creatures"
       date: "2023-03-28"
     MCV4EC:
-      name: "Monstrous Compendium Volume 3: 4: Eldraine Creatures"
+      name: "Monstrous Compendium Volume 4: Eldraine Creatures"
       date: "2023-09-21"
     MFF:
       name: "Mordenkainen's Fiendish Folio"


### PR DESCRIPTION
Took much longer than it should have, as I meant to include this in #740, but I finally got a method working to allow optional features to use full feature type names from homebrew. Pretty minor but figured it would be nice to include.

Also cleaned up the rest of the implementation for feat categories a bit and fixed a small bug that was dropping some prereqs.