### PR TITLE
🐛 Reformat subclass features

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonTextReplacement.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonTextReplacement.java
@@ -366,7 +366,9 @@ public interface JsonTextReplacement extends JsonTextConverter<Tools5eIndexType>
                         .replaceAll("\\{@cult ([^|}]+)\\|[^|}]+\\|([^|}]*)}", "$2")
                         .replaceAll("\\{@cult ([^|}]+)\\|[^}]*}", "$1")
                         .replaceAll("\\{@cult ([^|}]+)}", "$1")
-                        .replaceAll("\\{@language ([^|}]+)\\|?[^}]*}", "$1")
+                        .replaceAll("\\{@language ([^|}]+)\\|[^|}]*\\|([^|}]*)}", "$2")
+                        .replaceAll("\\{@language ([^|}]+)\\|[^}]*}", "$1")
+                        .replaceAll("\\{@language ([^|}]+)}", "$1")
                         .replaceAll("\\{@book ([^}|]+)\\|?[^}]*}", "\"$1\"")
                         .replaceAll("\\{@h}", "*Hit:* ") // render.js Renderer.tag
                         .replaceAll("\\{@m}", "*Miss:* ")


### PR DESCRIPTION
This started out as a simple addition but ballooned a little after some testing and catching edge cases. It works but may not be the cleanest or most efficient implementation. I didn't create an issue for this because I wasn't sure if it's correcting unintended behavior. If it isn't, I'll close this PR.

# Summarized Changes

1. Added new method `appendIntroText()` to `ClassFeature` to handle the first "feature" entry for subclasses
    - The first "feature" is primarily introductory fluff text for subclasses and is titled after the subclass name in the 5etools database
    - The first "feature" also contains the actual first leveled features of a subclass nested within it, so `appendIntroText()` injects a `## Subclass Features` header between the fluff and the first real feature
2. Changed `heading` to `null` in calls to `JsonSource.appendToText()`
    - This formats sub-entry names as bold text rather than headings, which better matches the source material
3. Added additional text replacement options for languages like what was added in #819.
    - Languages with display text are denoted in the 5etools database as `{@language Name|Source|DisplayText}` like `{@language Primordial||Aquan}`

# Testing and Examples

## Domain Spells in Nature Domain 2014 subclass

**Before:**
```markdown
## Class Features

### Nature Domain (Level 3)

Gods of nature are as varied as the natural world itself...

At each indicated cleric level, you add the listed spells to your spells prepared.

**Nature Domain Spells**

| Cleric Level | Spells |
|--------------|--------|
...
```

**After:**
```markdown
Gods of nature are as varied as the natural world itself...

## Subclass Features

### Domain Spells (Level 3)

At each indicated cleric level, you add the listed spells to your spells prepared.

**Nature Domain Spells**

| Cleric Level | Spells |
|--------------|--------|
...
```

## Entries in College of Valor 2024 subclass

**Before:**
```markdown
### Combat Inspiration (Level 3)

You can use your wit to turn the tide of battle. A creature that has a Bardic Inspiration die from you can use it for one of the following effects.

#### Defense

When the creature is hit by an attack roll, that creature can use its Reaction to roll the Bardic Inspiration die and add the number rolled to its AC against that attack, potentially causing the attack to miss.

#### Offense

Immediately after the creature hits a target with an attack roll, the creature can roll the Bardic Inspiration die and add the number rolled to the attack's damage against the target.
```

**After:**
```markdown
### Combat Inspiration (Level 3)

You can use your wit to turn the tide of battle. A creature that has a Bardic Inspiration die from you can use it for one of the following effects.

**Defense.** When the creature is hit by an attack roll, that creature can use its Reaction to roll the Bardic Inspiration die and add the number rolled to its AC against that attack, potentially causing the attack to miss.

**Offense.** Immediately after the creature hits a target with an attack roll, the creature can roll the Bardic Inspiration die and add the number rolled to the attack's damage against the target.
```

## Languages in Storm Sorcery subclass

**Before:**
```markdown
You can speak, read, and write Primordial.
Knowing this language allows you to understand and be understood by those who speak its dialects: Primordial, Primordial, Primordial, and Primordial.
```

**After:**
```markdown
You can speak, read, and write Primordial.
Knowing this language allows you to understand and be understood by those who speak its dialects: Aquan, Auran, Ignan, and Terran.
```