### PR TITLE
🐛 hpText in yaml statblocks

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
@@ -383,6 +383,10 @@ public class QuteMonster extends Tools5eQuteBase {
         addIntegerUnlessEmpty(map, "hp", acHp.hp);
         addUnlessEmpty(map, "hit_dice", acHp.hitDice);
 
+        if (acHp.hp == null) {
+            addUnlessEmpty(map, "hp", acHp.hpText);
+        }
+
         if (initiative != null) {
             map.put("modifier", initiative.bonus);
             // TODO: passive initiative?


### PR DESCRIPTION
Small addition to yaml statblocks checks for the `acHp.hpText` field if regular numeric hp doesn't exist. Fixes #893.