### PR TITLE
Add treasure property to monster statblocks (resolves #899)

### DIFF
--- a/docs/templates/dnd5e/QuteMonster/README.md
+++ b/docs/templates/dnd5e/QuteMonster/README.md
@@ -6,7 +6,7 @@ Extension of [Tools5eQuteBase](../Tools5eQuteBase.md).
 
 ## Attributes
 
-[5eInitiativeYaml](#5einitiativeyaml), [5eInitiativeYamlNoSource](#5einitiativeyamlnosource), [5eStatblockYaml](#5estatblockyaml), [5eStatblockYamlNoSource](#5estatblockyamlnosource), [ac](#ac), [acHp](#achp), [acText](#actext), [action](#action), [alignment](#alignment), [allTraits](#alltraits), [bonusAction](#bonusaction), [books](#books), [conditionImmune](#conditionimmune), [cr](#cr), [description](#description), [environment](#environment), [fluffImages](#fluffimages), [fullType](#fulltype), [gear](#gear), [getAliases](#getaliases), [hasImages](#hasimages), [hasMoreImages](#hasmoreimages), [hasSections](#hassections), [hitDice](#hitdice), [hp](#hp), [hpText](#hptext), [immune](#immune), [immuneResist](#immuneresist), [initiative](#initiative), [isNpc](#isnpc), [labeledSource](#labeledsource), [languages](#languages), [legendary](#legendary), [legendaryGroup](#legendarygroup), [legendaryGroupLink](#legendarygrouplink), [name](#name), [passive](#passive), [pb](#pb), [rawSpellcasting](#rawspellcasting), [reaction](#reaction), [reprintOf](#reprintof), [resist](#resist), [savesSkills](#savesskills), [savingThrows](#savingthrows), [scores](#scores), [senses](#senses), [showAllImages](#showallimages), [showMoreImages](#showmoreimages), [showPortraitImage](#showportraitimage), [size](#size), [skills](#skills), [source](#source), [sourceAndPage](#sourceandpage), [sourcesWithFootnote](#sourceswithfootnote), [speed](#speed), [spellcasting](#spellcasting), [subtype](#subtype), [tags](#tags), [text](#text), [token](#token), [trait](#trait), [type](#type), [vaultPath](#vaultpath), [vulnerable](#vulnerable)
+[5eInitiativeYaml](#5einitiativeyaml), [5eInitiativeYamlNoSource](#5einitiativeyamlnosource), [5eStatblockYaml](#5estatblockyaml), [5eStatblockYamlNoSource](#5estatblockyamlnosource), [ac](#ac), [acHp](#achp), [acText](#actext), [action](#action), [alignment](#alignment), [allTraits](#alltraits), [bonusAction](#bonusaction), [books](#books), [conditionImmune](#conditionimmune), [cr](#cr), [description](#description), [environment](#environment), [fluffImages](#fluffimages), [fullType](#fulltype), [gear](#gear), [getAliases](#getaliases), [hasImages](#hasimages), [hasMoreImages](#hasmoreimages), [hasSections](#hassections), [hitDice](#hitdice), [hp](#hp), [hpText](#hptext), [immune](#immune), [immuneResist](#immuneresist), [initiative](#initiative), [isNpc](#isnpc), [labeledSource](#labeledsource), [languages](#languages), [legendary](#legendary), [legendaryGroup](#legendarygroup), [legendaryGroupLink](#legendarygrouplink), [name](#name), [passive](#passive), [pb](#pb), [rawSpellcasting](#rawspellcasting), [reaction](#reaction), [reprintOf](#reprintof), [resist](#resist), [savesSkills](#savesskills), [savingThrows](#savingthrows), [scores](#scores), [senses](#senses), [showAllImages](#showallimages), [showMoreImages](#showmoreimages), [showPortraitImage](#showportraitimage), [size](#size), [skills](#skills), [source](#source), [sourceAndPage](#sourceandpage), [sourcesWithFootnote](#sourceswithfootnote), [speed](#speed), [spellcasting](#spellcasting), [subtype](#subtype), [tags](#tags), [text](#text), [token](#token), [trait](#trait), [treasure](#treasure), [type](#type), [vaultPath](#vaultpath), [vulnerable](#vulnerable)
 
 ### 5eInitiativeYaml
 
@@ -291,6 +291,10 @@ Token image as [ImageRef](../../ImageRef.md)
 ### trait
 
 Creature traits as a list of [NamedText](../../NamedText.md)
+
+### treasure
+
+Creature treasure themes as a list of links to the Random Magic Items tables (2024+)
 
 ### type
 

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteMonster.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteMonster.java
@@ -1,6 +1,7 @@
 package dev.ebullient.convert.tools.dnd5e;
 
 import static dev.ebullient.convert.StringUtil.pluralize;
+import static dev.ebullient.convert.StringUtil.toTitleCase;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -102,6 +103,7 @@ public class Json2QuteMonster extends Json2QuteCommon {
                 intOrDefault(rootNode, "passive", 10),
                 immuneResist(),
                 gear(),
+                treasure(),
                 joinAndReplace(rootNode, "languages"),
                 cr, pb,
                 initiative(abilityScores, cr),
@@ -579,6 +581,28 @@ public class Json2QuteMonster extends Json2QuteCommon {
         return gear;
     }
 
+    List<String> treasure() {
+        // 2024+ creatures list treasure themes as keys (e.g. "arcana", "relics").
+        // Known themes link to the Random Magic Items tables in the 2024 DMG (XDMG);
+        // anything else is passed through title-cased. Mirrors 5eTools getRenderedTreasure.
+        final List<String> knownThemes = List.of("arcana", "armaments", "implements", "relics");
+        List<String> themes = new ArrayList<>();
+        for (var node : MonsterFields.treasure.iterateArrayFrom(rootNode)) {
+            if (node != null && node.isTextual()) {
+                themes.add(node.asText());
+            }
+        }
+        themes.sort(String.CASE_INSENSITIVE_ORDER);
+        List<String> treasure = new ArrayList<>();
+        for (String theme : themes) {
+            String title = toTitleCase(theme);
+            treasure.add(knownThemes.contains(theme)
+                    ? replaceText("{@table Random Magic Items - %s|XDMG|%s}".formatted(title, title))
+                    : title);
+        }
+        return treasure;
+    }
+
     @Override
     public String getImagePath() {
         if (type != Tools5eIndexType.monster) {
@@ -880,6 +904,7 @@ public class Json2QuteMonster extends Json2QuteCommon {
         spells,
         summonedBySpellLevel,
         trait,
+        treasure,
         type,
         variant,
         will,

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/qute/QuteMonster.java
@@ -58,6 +58,8 @@ public class QuteMonster extends Tools5eQuteBase {
     public final ImmuneResist immuneResist;
     /** Creature gear as list of item links */
     public final List<String> gear;
+    /** Creature treasure themes as a list of links to the Random Magic Items tables (2024+) */
+    public final List<String> treasure;
 
     /** Creature speed as a comma-separated list */
     public final String speed;
@@ -95,7 +97,7 @@ public class QuteMonster extends Tools5eQuteBase {
             String subtype, String alignment,
             AcHp acHp, String speed,
             AbilityScores scores, SavesAndSkills savesSkills, String senses, int passive,
-            ImmuneResist immuneResist, List<String> gear,
+            ImmuneResist immuneResist, List<String> gear, List<String> treasure,
             String languages, String cr, String pb, Initiative initiative,
             Traits traits,
             List<Spellcasting> spellcasting,
@@ -119,6 +121,7 @@ public class QuteMonster extends Tools5eQuteBase {
         this.passive = passive;
         this.immuneResist = immuneResist;
         this.gear = gear;
+        this.treasure = treasure;
         this.languages = languages;
         this.cr = cr;
         this.pb = pb;
@@ -408,6 +411,7 @@ public class QuteMonster extends Tools5eQuteBase {
         addUnlessEmpty(map, "damage_immunities", immuneResist.immune);
         addUnlessEmpty(map, "condition_immunities", immuneResist.conditionImmune);
         addUnlessEmpty(map, "gear", gear);
+        addUnlessEmpty(map, "treasure", treasure);
         map.put("senses", (senses.isBlank() ? "" : senses + ", ") + "passive Perception " + passive);
         map.put("languages", languages);
         addUnlessEmpty(map, "cr", cr);

--- a/src/main/resources/templates/tools5e/monster2md.txt
+++ b/src/main/resources/templates/tools5e/monster2md.txt
@@ -42,6 +42,8 @@ title: {resource.name}{#if resource.token}
 {resource.immuneResist}
 {/if}{#if resource.gear}
 - **Gear** {resource.gear.join(", ")}
+{/if}{#if resource.treasure}
+- **Treasure** {resource.treasure.join(", ")}
 {/if}
 - **Languages** {#if resource.languages }{resource.languages}{#else}—{/if}
 - **Challenge** {resource.cr}


### PR DESCRIPTION
Resolves #899.

## Problem

2024 creatures carry a `treasure` field, but it was never parsed or exposed on `QuteMonster`. Any template that references `{resource.treasure}` therefore fails at render time:

```
io.quarkus.qute.TemplateException: Rendering error: Property "treasure" not found on the
base object "dev.ebullient.convert.tools.dnd5e.qute.QuteMonster" in expression {resource.treasure}
```

## Root cause

The `treasure` array (theme keys such as `"arcana"`, `"relics"`) simply wasn't read in `Json2QuteMonster` or surfaced on `QuteMonster` — the tool silently dropped it, so there was no property for a template to reference.

## Fix

Parse `treasure` in `Json2QuteMonster` and expose it on `QuteMonster` as `treasure`, mirroring the existing `gear` handling:

- Known treasure themes (`arcana`, `armaments`, `implements`, `relics`) link to the Random Magic Items tables (`{@table Random Magic Items - Arcana|XDMG|Arcana}`), and any other value is passed through title-cased — matching 5eTools' own `getRenderedTreasure`. Entries are sorted for stable output.
- The default `monster2md.txt` template now renders a **Treasure** line (right after **Gear**).
- `docs/templates/dnd5e/QuteMonster/README.md` was regenerated by `process-sources` from the new field's javadoc.

`treasure` is kept distinct from `gear`: `gear` is the items a creature carries, `treasure` is the thematic Random Magic Items tables suggested for its loot.

## Verification

Reproduced the exact error above with a 2024 creature (`"treasure": ["arcana", "relics"]`) and a template referencing `{resource.treasure}`. After the change, the same conversion succeeds and renders:

```
- **Treasure** Arcana, Relics
```

(Themes resolve to their table links when the source is available, and degrade to plain title-cased text otherwise.) `./mvnw process-sources` is clean.

Happy to add a CHANGELOG entry under whichever heading you'd like — I left it out rather than guess the target version.
