### PR TITLE
🐛 Feat category and prerequisite text

### DIFF
--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/Json2QuteCommon.java
@@ -367,8 +367,11 @@ public class Json2QuteCommon implements JsonSource {
         for (JsonNode p : iterableElements(profPrereq)) {
             for (Entry<String, JsonNode> prof : iterableFields(p)) {
                 switch (prof.getKey()) {
-                    case "armor" -> profs.add(String.format("%s armor",
-                            replaceText(prof.getValue().asText())));
+                    case "armor" -> {
+                        String armor = replaceText(prof.getValue().asText());
+                        armor = armor.equals("shield") ? armor + "s" : armor + " armor";
+                        profs.add(armor);
+                    }
                     case "weapon" -> profs.add(String.format("a %s weapon",
                             replaceText(prof.getValue().asText())));
                     case "weaponGroup" -> profs.add(String.format("%s weapons",
@@ -518,12 +521,14 @@ public class Json2QuteCommon implements JsonSource {
                     case background -> values.add(backgroundPrereq(value));
                     case campaign -> values.add(replaceConjoinOr(value, " Campaign"));
                     case culture -> values.add(replaceConjoinOr(value, " Culture"));
-                    case exclusiveFeatCategory -> values.add("Can't Have Another " + replaceConjoinOr(value, " Feat"));
+                    case exclusiveFeatCategory -> values.add("Can't Have Another " +
+                            JsonSource.featureTypeToString(replaceConjoinOr(value, ""), Map.of()));
                     case expertise -> values.add(expertisePrereq(value));
                     case feat -> values.add(featPrereq(value));
-                    case featCategory -> values.add("Any " + replaceConjoinOr(value, " Feat"));
+                    case featCategory -> values.add("Any " +
+                            JsonSource.featureTypeToString(replaceConjoinOr(value, ""), Map.of()));
                     case feature -> values.add(replaceConjoinOr(value, " Feature"));
-                    case optionalfeature -> values.add(replaceConjoinOr(value, ""));
+                    case optionalfeature -> values.add(replaceText("{@optfeature " + replaceConjoinOr(value, "") + "}"));
                     case group -> values.add(replaceConjoinOr(value, " Group"));
                     case item -> values.add(replaceConjoinOr(value, ""));
                     case itemProperty -> values.add(itemPropertyPrereq(value));

--- a/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
+++ b/src/main/java/dev/ebullient/convert/tools/dnd5e/JsonSource.java
@@ -1409,7 +1409,8 @@ public interface JsonSource extends JsonTextReplacement {
         // Parser.FEAT_CATEGORY_TO_FULL
         // Parser.OPT_FEATURE_TYPE_TO_FULL
         return switch (featureType.toUpperCase()) {
-            case "D" -> "Dragonmark";
+            case "D" -> "Dragonmark Feat";
+            case "DG" -> "Dark Gift Feat";
             case "EB" -> "Epic Boon Feat";
             case "FS" -> "Fighting Style Feat";
             case "G" -> "General Feat";
@@ -1430,6 +1431,7 @@ public interface JsonSource extends JsonTextReplacement {
             case "FS:P" -> "Fighting Style, Paladin";
             case "FS:R" -> "Fighting Style, Ranger";
             case "PB" -> "Pact Boon";
+            case "PPACT" -> "Planar Pact Feat";
             case "OR" -> "Onomancy Resonant";
             case "RN" -> "Rune Knight Rune";
             case "AF" -> "Alchemical Formula";


### PR DESCRIPTION
Resolves #915.

Implementation of `featureTypeToString()` and `replaceText()` within `listPrerequisites()` may be a little messy. Possible there could be a cleaner way of doing it.